### PR TITLE
Improve Black output with diff and color options

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,7 +41,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: psf/black@stable
         with:
-          options: '--check --verbose -t py36'
+          options: '--check --diff --color --verbose -t py36'
           src: ${{ steps.changed-files.outputs.all_changed_files }}
   shellcheck:
     name: Shellcheck


### PR DESCRIPTION
This replaces the vague "would format" message with a proper line-by-line unified diff.

Story: ROCm/jax-internal#92
Ref: https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#diff