### PR TITLE
Use internal ROCm builds for nightly test runs

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -6,6 +6,16 @@ on:
       rocm-version:
         required: true
         type: string
+      rocm-build-job:
+        required: false
+        type: string
+      rocm-build-num:
+        required: false
+        type: string
+      runner-label:
+        required: false
+        type: string
+        default: "mi-250"
       artifact-prefix:
         required: false
         default: 'plugin_wheels'
@@ -13,7 +23,7 @@ on:
 
 jobs:
   build-docker:
-    runs-on: mi-250
+    runs-on: ${{ inputs.runner-label }}
     steps:
       - name: Clean up old runs
         run: |
@@ -37,7 +47,9 @@ jobs:
       - name: Build JAX docker image
         run: |
           python3 build/ci_build \
-            --rocm-version ${{ inputs.rocm-version }} \
+            --rocm-version="${{ inputs.rocm-version }}" \
+            --rocm-build-job="${{ inputs.rocm-build-job }}" \
+            --rocm-build-num="${{ inputs.rocm-build-num }}" \
             build_dockers
       - name: Authenticate to GitHub Container Registry
         run: |
@@ -47,12 +59,12 @@ jobs:
         env:
           ROCM_VERSION: ${{ inputs.rocm-version }}
         run: |
-          docker tag \
-            "jax-ubu22.rocm${ROCM_VERSION//.}" \
-            "ghcr.io/rocm/jax-ubu22.rocm${ROCM_VERSION//.}:${GITHUB_SHA}"
-          docker tag \
-            "jax-ubu24.rocm${ROCM_VERSION//.}" \
-            "ghcr.io/rocm/jax-ubu24.rocm${ROCM_VERSION//.}:${GITHUB_SHA}"
-          docker push "ghcr.io/rocm/jax-ubu22.rocm${ROCM_VERSION//.}:${GITHUB_SHA}"
-          docker push "ghcr.io/rocm/jax-ubu24.rocm${ROCM_VERSION//.}:${GITHUB_SHA}"
+          ubu22_img="ghcr.io/rocm/jax-ubu22.rocm${ROCM_VERSION//.}:${GITHUB_SHA}"
+          ubu24_img="ghcr.io/rocm/jax-ubu24.rocm${ROCM_VERSION//.}:${GITHUB_SHA}"
+          echo "Ubuntu 22 image name: ${ubu22_img}"
+          echo "Ubuntu 24 image name: ${ubu24_img}"
+          docker tag "jax-ubu22.rocm${ROCM_VERSION//.}" "${ubu22_img}"
+          docker tag "jax-ubu24.rocm${ROCM_VERSION//.}" "${ubu24_img}"
+          docker push "${ubu22_img}"
+          docker push "${ubu24_img}"
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -9,6 +9,16 @@ on:
       rocm-version:
         required: true
         type: string
+      rocm-build-job:
+        required: false
+        type: string
+      rocm-build-num:
+        required: false
+        type: string
+      runner-label:
+        required: false
+        type: string
+        default: "mi-250"
       artifact-prefix:
         required: false
         default: 'plugin_wheels'
@@ -16,7 +26,7 @@ on:
 
 jobs:
   build-plugin-wheels:
-    runs-on: mi-250
+    runs-on: ${{ inputs.runner-label }}
     steps:
       - name: Clean up old runs
         run: |
@@ -35,9 +45,11 @@ jobs:
       - name: Build plugin wheels
         run: |
           python3 build/ci_build \
-            --compiler clang \
-            --python-versions ${{ inputs.python-versions }} \
-            --rocm-version ${{ inputs.rocm-version }} \
+            --compiler=clang \
+            --python-versions="${{ inputs.python-versions }}" \
+            --rocm-version="${{ inputs.rocm-version }}" \
+            --rocm-build-job="${{ inputs.rocm-build-job }}" \
+            --rocm-build-num="${{ inputs.rocm-build-num }}" \
             dist_wheels
       - name: Archive plugin wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - 'release/*'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -18,7 +19,7 @@ jobs:
   call-build-wheels:
     strategy:
       matrix:
-        rocm-version: ["6.3.3"]
+        rocm-version: ["6.4.1"]
     uses: ./.github/workflows/build-wheels.yml
     with:
       # TODO: Add back Python 3.13 when we're ready to move to a more recent version of XLA. 3.13
@@ -29,7 +30,7 @@ jobs:
     needs: call-build-wheels
     strategy:
       matrix:
-        rocm-version: ["6.3.3"]
+        rocm-version: ["6.4.1"]
     uses: ./.github/workflows/build-docker.yml
     with:
       rocm-version: ${{ matrix.rocm-version }}
@@ -38,7 +39,7 @@ jobs:
     runs-on: mi-250
     strategy:
       matrix:
-        rocm-version: ["6.3.3"]
+        rocm-version: ["6.4.1"]
     steps:
       - name: Checkout plugin repo
         uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,48 +3,70 @@ name: Nightly
 on:
   schedule:
     - cron: "0 1 * * *"
+  workflow_dispatch:
 
 concurrency:
   cancel-in-progress: true
-
-env:
-  PYTHON_VERSIONS: "3.10.13,3.12.8"
 
 jobs:
   call-build-wheels:
     strategy:
       matrix:
-        rocm-version: ["6.3.3"]
-    uses: jax/rocm-jax/.github/workflows/reuseable/build-wheels.yml@master
+        rocm-version: ["6.4.1", "7.0"]
+        include:
+          - rocm-version: "7.0"
+            rocm-build-job: "compute-rocm-dkms-no-npi-hipclang"
+            rocm-build-num: "16090"
+            runner-label: "internal"
+    uses: ./.github/workflows/build-wheels.yml
     with:
-      python-versions: ${{ env.PYTHON_VERSIONS }}
+      python-versions: "3.10,3.12"
       rocm-version: ${{ matrix.rocm-version }}
+      rocm-build-job: ${{ matrix.rocm-build-job }}
+      rocm-build-num: ${{ matrix.rocm-build-num }}
+      runner-label: ${{ matrix.runner-label }}
   call-build-docker:
+    needs: call-build-wheels
     strategy:
       matrix:
-        python-version: ["3.10.13,3.12.8"]
-        rocm-version: ["6.3.3"]
-    uses: jax/rocm-jax/.github/workflows/reusable/build-docker.yml@master
+        rocm-version: ["6.4.1", "7.0"]
+        include:
+          - rocm-version: "7.0"
+            rocm-build-job: "compute-rocm-dkms-no-npi-hipclang"
+            rocm-build-num: "16090"
+            runner-label: "internal"
+    uses: ./.github/workflows/build-docker.yml
     with:
-      rocm-version: ${{ matrix.python-version }}
+      rocm-version: ${{ matrix.rocm-version }}
+      rocm-build-job: ${{ matrix.rocm-build-job }}
+      rocm-build-num: ${{ matrix.rocm-build-num }}
+      runner-label: ${{ matrix.runer-label }}
   run-python-unit-tests:
+    needs: call-build-docker
+    runs-on: mi-250
     strategy:
       matrix:
-        rocm-version: ["6.3.3"]
+        rocm-version: ["6.4.1", "7.0"]
+        ubuntu-version: ["22", "24"]
     steps:
       - name: Checkout plugin repo
         uses: actions/checkout@v4
       - name: Checkout JAX repo
-        uses: actions/chekcout@v4
+        uses: actions/checkout@v4
         with:
-          repository: jax-ml/jax
+          # TODO: Load the ref from a file that sets the min and max JAX version
+          # TODO: Change the repo and ref once we figure out how exactly we're going to
+          #       manage tests
+          repository: rocm/jax
+          ref: rocm-jaxlib-v0.6.0
           path: jax
       - name: Run tests
         env:
           GPU_COUNT: "8"
           GFX: "gfx90a"
           ROCM_VERSION: ${{ matrix.rocm-version }}
+          UBUNTU_VERSION: ${{ matrix.ubuntu-version }}
         run: |
-          python3 build/ci_build test "ghcr.io/rocm/jax-ubu22.rocm${ROCM_VERSION//.}:${GITHUB_REF_NAME}" --test-cmd "pytest tests"
-
-
+          python3 build/ci_build test \
+            "ghcr.io/rocm/jax-ubu${UBUNTU_VERSION}.rocm${ROCM_VERSION//.}:${GITHUB_SHA}" \
+            --test-cmd "pytest tests/"


### PR DESCRIPTION
Fixes the nightly workflow to be in line with the regular CI workflow with the addition of building against internal, not-yet-released, ROCm builds. For now, this is what the PR and nightly CI will do,

On every PR:
* Build wheels against ROCm 6.4.1 for Python 3.10 and 3.12
* Build an Ubuntu 22 with Python 3.10 and an Ubuntu 24 with Python 3.12
* Run core tests against the Ubuntu 22 image on an MI250 machine

Nightly:
* Build wheels against ROCm 6.4.1 and an internal 7.0 build for Python 3.10 and 3.12
* Build two Ubuntu 22 images with Python 3.10, one with ROCm 6.4.1 and one with ROCm 7.0
* Build two Ubuntu 24 images with Python 3.12, one with ROCm 6.4.1 and one with ROCm 7.0
* Run the full test suite against all four images on an MI250 machine