### PR TITLE
Add scripts to run linters locally

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   pylint:

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,3 @@
+[MESSAGES CONTROL]
+
+disable = consider-using-f-string

--- a/stack.py
+++ b/stack.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
+"""Script for setting up local development environments"""
 
 import argparse
 import os
 import subprocess
-import sys
 
 
 JAX_REPO_REF = "rocm-jaxlib-v0.6.0"
@@ -94,9 +94,12 @@ def find_clang():
                 clang_path = os.path.join(root, f)
                 return clang_path
 
+    # We didn't find a clang install
+    return None
+
 
 def setup_development(jax_ref: str, xla_ref: str, rebuild_makefile: bool = False):
-    # clone jax repo for jax test case source code
+    """Clone jax repo for jax test case source code"""
 
     if not os.path.exists("./jax"):
         cmd = ["git", "clone"]
@@ -127,11 +130,12 @@ def setup_development(jax_ref: str, xla_ref: str, rebuild_makefile: bool = False
 
         makefile_content = MAKE_TEMPLATE % kvs
 
-        with open(makefile_path, "w") as mf:
+        with open(makefile_path, "w", encoding="utf-8") as mf:
             mf.write(makefile_content)
 
 
 def dev_docker():
+    """Start a docker container for local plugin development"""
     cur_abs_path = os.path.abspath(os.curdir)
     image_name = "ubuntu:22.04"
 
@@ -162,8 +166,8 @@ def dev_docker():
 
     cmd.append(image_name)
 
-    p = subprocess.Popen(cmd)
-    p.wait()
+    with subprocess.Popen(cmd) as p:
+        p.wait()
 
 
 # build mode setup
@@ -172,10 +176,12 @@ def dev_docker():
 # install jax/jaxlib from known versions
 # setup build/install/test script
 def setup_build():
+    """Setup for building the plugin locally"""
     raise NotImplementedError
 
 
 def parse_args():
+    """Parse command line arguments"""
     p = argparse.ArgumentParser()
 
     subp = p.add_subparsers(dest="action", required=True)
@@ -197,12 +203,12 @@ def parse_args():
         default=JAX_REPO_REF,
     )
 
-    docker = subp.add_parser("docker")
-
+    subp.add_parser("docker")
     return p.parse_args()
 
 
 def main():
+    """Run commands depending on command line input"""
     args = parse_args()
     if args.action == "docker":
         dev_docker()

--- a/tools/blacken.sh
+++ b/tools/blacken.sh
@@ -5,7 +5,9 @@ FILES=(
   stack.py
 )
 
-FILES+=($(find build -name "*.py"))
-FILES+=($(find tools -name "*.py"))
+mapfile -t FILES < <(find build -name "*.py")
+mapfile -t FILES < <(find tools -name "*.py")
 
-black -t py36 $* ${FILES[@]}
+#shellcheck disable=SC2068
+black -t py36 "$@" ${FILES[@]}
+

--- a/tools/docker_dev_setup.sh
+++ b/tools/docker_dev_setup.sh
@@ -69,7 +69,10 @@ apt-get install -y \
   patchelf \
   python3.10-venv \
   lsb-release \
-  cmake || die "error installing dependencies"
+  cmake \
+  yamllint \
+  shellcheck \
+  git || die "error installing dependencies"
 
 # install a clang
 install_clang_packages || die "error while installing clang"
@@ -85,6 +88,11 @@ python -m venv .venv
 info "Entering virtualenv"
 # shellcheck disable=SC1091
 . .venv/bin/activate
+
+# Install Python linting tools
+python -m pip install \
+  black \
+  pylint
 
 if [ -n "$_IS_ENTRYPOINT" ]; then
   # run CMD from docker

--- a/tools/pylint.sh
+++ b/tools/pylint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+FILES=$(git diff --name-only HEAD -- '*.py' build/ci_build)
+#shellcheck disable=SC2068
+pylint "$@" ${FILES[@]}
+

--- a/tools/shellcheck.sh
+++ b/tools/shellcheck.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+FILES=$(git diff --name-only HEAD -- '*.sh')
+#shellcheck disable=SC2068
+shellcheck "$@" ${FILES[@]}
+

--- a/tools/yamllint.sh
+++ b/tools/yamllint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+FILES=$(git diff --name-only HEAD -- '*.yaml' '*.yml')
+#shellcheck disable=SC2068
+yamllint "$@" ${FILES[@]}
+


### PR DESCRIPTION
Adds a few scripts for running linters locally, installs them in the dev container, and adds a .pylintrc to ignore f-string warnings. Also brings the `stack.py` script in line with Pylint.

https://github.com/ROCm/jax-internal/issues/92