### PR TITLE
Add group setting to nightly CI concurrency

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Add a group setting for the nightly CI job so that it will only run once per branch and will cancel any in-progress jobs. Useful if the job hangs. The next nightly job will kill the hung job.