### PR TITLE
Add step to make sure we can clean up old files

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           ls
           # Make sure that we own all of the files so that we have permissions to delete them
-          docker run -v "./:/rocm-jax" ubuntu /bin/bash -c "chown -R $UID /rocm-jax/* || true"
+          docker run --rm -v "./:/rocm-jax" ubuntu /bin/bash -c "chown -R $UID /rocm-jax/* || true"
           # Remove any old work directories from this machine
           rm -rf * || true
           ls

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           ls
           # Make sure that we own all of the files so that we have permissions to delete them
-          docker run -v "./:/rocm-jax" ubuntu /bin/bash -c "chown -R $UID /rocm-jax/* || true"
+          docker run --rm -v "./:/rocm-jax" ubuntu /bin/bash -c "chown -R $UID /rocm-jax/* || true"
           # Remove any old work directories from this machine
           rm -rf * || true
           ls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       matrix:
         rocm-version: ["6.4.1"]
     steps:
+      - name: Change owners for cleanup
+        run: |
+          docker run --rm -v "./:/rocm-jax" ubuntu /bin/bash -c "chown -R $UID /rocm-jax/* || true"
       - name: Checkout plugin repo
         uses: actions/checkout@v4
       - name: Checkout JAX repo

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,6 +50,9 @@ jobs:
         rocm-version: ["6.4.1", "7.0"]
         ubuntu-version: ["22", "24"]
     steps:
+      - name: Change owners for cleanup
+        run: |
+          docker run --rm -v "./:/rocm-jax" ubuntu /bin/bash -c "chown -R $UID /rocm-jax/* || true"
       - name: Checkout plugin repo
         uses: actions/checkout@v4
       - name: Checkout JAX repo

--- a/.github/workflows/update-xla-hash.yml
+++ b/.github/workflows/update-xla-hash.yml
@@ -16,8 +16,12 @@ on:
 jobs:
   update-xla-hash:
     env:
+      # yamllint disable-line rule:line-length
       NEW_BRANCH_NAME: ci-xlahash-${{ github.ref_name }}_${{ github.run_id }}}_${{ github.run_number }}_${{ github.run_attempt }}
     steps:
+      - name: Change owners for cleanup
+        run: |
+          docker run --rm -v "./:/rocm-jax" ubuntu /bin/bash -c "chown -R $UID /rocm-jax/* || true"
       - uses: actions/checkout@v4
       - name: Generate an app token
         id: generate-token
@@ -26,9 +30,12 @@ jobs:
           app-id: ${{ vars.ROCM_REPO_MANAGEMENT_API_2_ID }}
           private-key: ${{ secrets.ROCM_REPO_MANAGEMENT_API_2_PRIV_KEY }}
       - name: Run update script
-        run: python3 tools/update_xla_hash.py -v --xla-repo ${{ inputs.xla_repo }} --gh-token $GH_TOKEN ${{ inputs.xla_hash }}
+        run: |
+          python3 tools/update_xla_hash.py -v \
+            --xla-repo ${{ inputs.xla_repo }} \
+            --gh-token $GH_TOKEN ${{ inputs.xla_hash }}
         env:
-           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Create branch for PR
         run: |
           git checkout -b $NEW_BRANCH_NAME
@@ -36,8 +43,12 @@ jobs:
           git config --global user.name "GitHub Actions"
           git push origin HEAD
       - name: Open PR
-        run: gh pr create --repo ${{ github.repository }} --head $NEW_BRANCH_NAME --base ${{ github.ref_name }} --title "CI: $(date +%x) XLA hash update" --body "Update the XLA commit hash"
+        run: |
+          gh pr create \
+            --repo ${{ github.repository }} \
+            --head $NEW_BRANCH_NAME \
+            --base ${{ github.ref_name }} \
+            --title "CI: $(date +%x) XLA hash update" \
+            --body "Update the XLA commit hash"
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-
-

--- a/.github/workflows/upstream-ci-watcher.yml
+++ b/.github/workflows/upstream-ci-watcher.yml
@@ -9,6 +9,9 @@ jobs:
   upstream-ci-watcher:
     runs-on: ubuntu-latest
     steps:
+      - name: Change owners for cleanup
+        run: |
+          docker run --rm -v "./:/rocm-jax" ubuntu /bin/bash -c "chown -R $UID /rocm-jax/* || true"
       - name: Checkout plugin repo
         uses: actions/checkout@v4
       - name: Run watcher script


### PR DESCRIPTION
Running builds and tests in docker containers will sometimes leave files in our workspace directory that are owned by the root user. The runner doesn't run under root and isn't able to delete these files as it normally would when running `actions/checkout`. Add steps to change the owner of any old files back to the user that the runner runs as before doing a checkout. Also, make sure we're cleaning up old docker containers when cleaning.