### PR TITLE
Clean up the cleanup container

### DIFF
--- a/.github/workflows/rocm-perf.yml
+++ b/.github/workflows/rocm-perf.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Clean up old workdirs
         run: |
           ls -l
-          docker run -v "$(pwd):/rocm-jax" ubuntu bash -c "chown -R $UID /rocm-jax/* || true"
+          docker run --rm -v "$(pwd):/rocm-jax" ubuntu bash -c "chown -R $UID /rocm-jax/* || true"
           rm -rf * || true
           ls -l
 


### PR DESCRIPTION
Remove the cleanup container when we're done with it so that we don't fill up the CI machine's disk