### PR TITLE
Restrict perf job to run nightly, or manually

### DIFF
--- a/.github/workflows/rocm-perf.yml
+++ b/.github/workflows/rocm-perf.yml
@@ -1,7 +1,9 @@
 name: ROCm DLM Performance Evaluations
 
 on:
-  push:
+  schedule:
+    - cron: '0 3 * * *'  # Nightly at 3:00 AM UTC
+  workflow_dispatch:
 
 jobs:
   build-and-test-jax-perf:


### PR DESCRIPTION
ci: restrict perf job to run on master branch, nightly, or manually

- Updated the `on:` block in the ROCm DLM performance workflow
- Now runs only on:
  - a nightly schedule at 3:00 AM UTC (as our usual nightly runs before, I am just avoiding the overlap)
  - manual dispatch via `workflow_dispatch` from the GitHub Actions UI