### PR TITLE
Remove continue on error and fix invalid workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,6 @@ concurrency:
 
 jobs:
   call-build-wheels:
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Broke this workflow by adding the continue-on-error flag. I guess it doesn't work for reusable workflows. Removing. The docs aren't 100% clear to me on how `continue-on-workflow` and `fail-fast` work together when one matrix build follows another, so maybe we don't even need `continue-on-workflow`.