### PR TITLE
Fix Docker patch step for ROCm >= 7.0: escape

### DIFF
--- a/docker/Dockerfile.jax-ubu22
+++ b/docker/Dockerfile.jax-ubu22
@@ -65,7 +65,7 @@ COPY jax_rocm_plugin/third_party/jax/namespace.patch /tmp/namespace.patch
 RUN bash -c '  \
     major_version=$(echo "$ROCM_VERSION" | cut -d. -f1) && \
     if [ "$major_version" -ge 7 ]; then \
-	dist_packages=$(python3 -c "import sysconfig; print(sysconfig.get_paths()['purelib'])") && \
+	dist_packages=$(python3 -c "import sysconfig; print(sysconfig.get_paths()[\"purelib\"])") && \
 	patch -p1 -d "$dist_packages" < /tmp/namespace.patch; \
     else \
         echo "ROCm version $ROCM_VERSION, skipping patch."; \

--- a/docker/Dockerfile.jax-ubu24
+++ b/docker/Dockerfile.jax-ubu24
@@ -65,7 +65,7 @@ RUN bash -c '  \
     major_version=$(echo "$ROCM_VERSION" | cut -d. -f1) && \
     if [ "$major_version" -ge 7 ]; then \
         echo "Applying patch for ROCm $ROCM_VERSION..."; \
-        dist_packages=$(python3 -c "import sysconfig; print(sysconfig.get_paths()['purelib'])") && \
+        dist_packages=$(python3 -c "import sysconfig; print(sysconfig.get_paths()[\"purelib\"])") && \
         patch -p1 -d "$dist_packages" < /tmp/namespace.patch; \
     else \
         echo "ROCm version $ROCM_VERSION, skipping patch."; \


### PR DESCRIPTION
Fix Docker patch step for ROCm >= 7.0: escape 'purelib' key in sysconfig call

The Docker build fails during the namespace patch step for ROCm >= 7.0 with:

    NameError: name 'purelib' is not defined

This is caused by unescaped single quotes around ['purelib'] inside a double-quoted
Python command within `bash -c`, which Bash misinterprets as a shell variable.

We fix this by switching to a single-quoted Python command and using double quotes
for the dictionary key access:

    python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])'

Note: This issue does not occur in CI with ROCm 6.4.1 because the patch step is
only triggered for ROCm versions 7.0 and above.