### PR TITLE
Add nightly docker tag and pull instructions

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -20,6 +20,9 @@ on:
         required: false
         default: 'plugin_wheels'
         type: string
+      extra-cr-tag:
+        required: false
+        type: string
 
 jobs:
   build-docker:
@@ -59,10 +62,25 @@ jobs:
             | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Push docker images
         env:
+          EXTRA_CR_TAG: ${{ inputs.extra-cr-tag }}
           ROCM_VERSION: ${{ inputs.rocm-version }}
         run: |
           ubu22_img="ghcr.io/rocm/jax-ubu22.rocm${ROCM_VERSION//.}:${GITHUB_SHA}"
           ubu24_img="ghcr.io/rocm/jax-ubu24.rocm${ROCM_VERSION//.}:${GITHUB_SHA}"
+          echo "Ubuntu 22 image name: ${ubu22_img}"
+          echo "Ubuntu 24 image name: ${ubu24_img}"
+          docker tag "jax-ubu22.rocm${ROCM_VERSION//.}" "${ubu22_img}"
+          docker tag "jax-ubu24.rocm${ROCM_VERSION//.}" "${ubu24_img}"
+          docker push "${ubu22_img}"
+          docker push "${ubu24_img}"
+      - name: Push extra tags
+        if: ${{ inputs.extra-cr-tag }}
+        env:
+          EXTRA_CR_TAG: ${{ inputs.extra-cr-tag }}
+          ROCM_VERSION: ${{ inputs.rocm-version }}
+        run: |
+          ubu22_img="ghcr.io/rocm/jax-ubu22.rocm${ROCM_VERSION//.}:${EXTRA_CR_TAG}"
+          ubu24_img="ghcr.io/rocm/jax-ubu24.rocm${ROCM_VERSION//.}:${EXTRA_CR_TAG}"
           echo "Ubuntu 22 image name: ${ubu22_img}"
           echo "Ubuntu 24 image name: ${ubu24_img}"
           docker tag "jax-ubu22.rocm${ROCM_VERSION//.}" "${ubu22_img}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,10 +38,12 @@ jobs:
         include:
           - rocm-version: "6.4.1"
             runner-label: "mi-250"
+            extra-cr-tag: "nightly"
           - rocm-version: "7.0"
             rocm-build-job: "compute-rocm-dkms-no-npi-hipclang"
             rocm-build-num: "16322"
             runner-label: "internal"
+            extra-cr-tag: "nightly"
     uses: ./.github/workflows/build-docker.yml
     with:
       rocm-version: ${{ matrix.rocm-version }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 `rocm-jax` contains sources for the ROCm plugin for JAX, as well as Dockerfiles used to build AMDs `rocm/jax` images.
 
-
 # development setup
 
 Run stack.py develop to clone jax/xla
@@ -141,3 +140,35 @@ Use make to build the plugin
 ```
 (cd jax_rocm_plugin && make clean dist)
 ```
+
+# Nightly Builds
+
+We build rocm-jax nightly with [a Github Actions workflow](https://github.com/ROCm/rocm-jax/actions/workflows/nightly.yml).
+
+## Docker
+
+Nightly docker images are kept in the Github Container Registry
+
+```
+echo <MY_GITHUB_ACCESS_TOKEN> | docker login ghcr.io -u <USERNAME> --password-stdin
+docker pull ghcr.io/rocm/jax-ubu24.rocm70:nightly
+```
+
+You can also find nightly images for other Ubuntu versions and ROCm version as well as older nightly images on the [packages page](https://github.com/orgs/ROCm/packages?repo_name=rocm-jax). Images get tagged with the git commit hash of the commit that the image was built from.
+
+### Authenticating to the Container Registry
+
+Pull access to the Github CR is done by a personal access token (classic) with the `read:packages` permission. To create one, click your profile picture in the top-right of Github, select Settings > Developer settings > Personal access tokens > Tokens (classic) and then select the option to generate a new token. Make sure you select the classic token option and git it the `read:packages` permission.
+
+Once your token has been created, go back to the Tokens (classic) page and set your token's SSO settings to allow access to the ROCm Github organization.
+
+Once your token has been set up to use SSO, you can log in with the `docker` command line by running,
+
+```
+echo <MY_GITHUB_ACCESS_TOKEN> | docker login ghcr.io -u <USERNAME> --password-stdin
+```
+
+## Wheels
+
+Wheels get saved as artifacts to each run of the nightly workflow. Go to the [nightly workflow](https://github.com/ROCm/rocm-jax/actions/workflows/nightly.yml), select the run you want to get wheels from, and scroll down to the bottom of the page to find the build artifacts. Each artifact is a zip file that contains all of the wheels built for a specific ROCm version.
+


### PR DESCRIPTION
We've been building nightly wheels and docker images for a while. This adds a `nightly` tag to the built docker images and instructions to the README that explains how to get the nightly images and wheels.