### PR TITLE
[master] rocm usecase install doesn't require amdgpu repo addition

### DIFF
--- a/build/tools/get_rocm.py
+++ b/build/tools/get_rocm.py
@@ -96,7 +96,6 @@ UBUNTU = System(
 RHEL8 = System(
     pkgbin="dnf",
     rocm_package_list=[
-        "libdrm-amdgpu",
         "rocm-dev",
         "rocm-ml-sdk",
         "miopen-hip ",
@@ -301,6 +300,7 @@ gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
 """
             % rocm_version_str
         )
+
 
 
 def parse_args():

--- a/build/tools/get_rocm.py
+++ b/build/tools/get_rocm.py
@@ -272,12 +272,6 @@ def setup_repos_ubuntu(rocm_version_str):
     keyadd = "wget -qO - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -"
     subprocess.check_call(keyadd, shell=True)
 
-    with open("/etc/apt/sources.list.d/amdgpu.list", "w") as fd:
-        fd.write(
-            ("deb [arch=amd64] " "https://repo.radeon.com/amdgpu/%s/ubuntu %s main\n")
-            % (rocm_version_str, codename)
-        )
-
     with open("/etc/apt/sources.list.d/rocm.list", "w") as fd:
         fd.write(
             ("deb [arch=amd64] " "https://repo.radeon.com/rocm/apt/%s %s main\n")
@@ -301,19 +295,6 @@ def setup_repos_el8(rocm_version_str):
 [ROCm]
 name=ROCm
 baseurl=http://repo.radeon.com/rocm/rhel8/%s/main
-enabled=1
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-"""
-            % rocm_version_str
-        )
-
-    with open("/etc/yum.repos.d/amdgpu.repo", "w") as afd:
-        afd.write(
-            """
-[amdgpu]
-name=amdgpu
-baseurl=https://repo.radeon.com/amdgpu/%s/rhel/8.8/main/x86_64/
 enabled=1
 gpgcheck=1
 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key

--- a/build/tools/get_rocm.py
+++ b/build/tools/get_rocm.py
@@ -153,19 +153,8 @@ def _setup_internal_repo(system, rocm_version, job_name, build_num):
 
     install_amdgpu_installer_internal(rocm_version)
 
-    amdgpu_build = (
-        urllib.request.urlopen(
-            "http://rocm-ci.amd.com/job/%s/%s/artifact/amdgpu_kernel_info.txt"
-            % (job_name, build_num)
-        )
-        .read()
-        .decode("utf8")
-        .strip()
-    )
-
     cmd = [
         "amdgpu-repo",
-        "--amdgpu-build=%s" % amdgpu_build,
         "--rocm-build=%s/%s" % (job_name, build_num),
     ]
     LOG.info("Running %r" % cmd)

--- a/build/tools/get_rocm.py
+++ b/build/tools/get_rocm.py
@@ -302,7 +302,6 @@ gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
         )
 
 
-
 def parse_args():
     p = argparse.ArgumentParser()
     p.add_argument("--rocm-version", help="ROCm version to install", default="latest")

--- a/jax_rocm_plugin/build/rocm/tools/get_rocm.py
+++ b/jax_rocm_plugin/build/rocm/tools/get_rocm.py
@@ -302,7 +302,6 @@ gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
         )
 
   
-
 def parse_args():
     p = argparse.ArgumentParser()
     p.add_argument("--rocm-version", help="ROCm version to install", default="latest")

--- a/jax_rocm_plugin/build/rocm/tools/get_rocm.py
+++ b/jax_rocm_plugin/build/rocm/tools/get_rocm.py
@@ -153,19 +153,8 @@ def _setup_internal_repo(system, rocm_version, job_name, build_num):
 
     install_amdgpu_installer_internal(rocm_version)
 
-    amdgpu_build = (
-        urllib.request.urlopen(
-            "http://rocm-ci.amd.com/job/%s/%s/artifact/amdgpu_kernel_info.txt"
-            % (job_name, build_num)
-        )
-        .read()
-        .decode("utf8")
-        .strip()
-    )
-
     cmd = [
         "amdgpu-repo",
-        "--amdgpu-build=%s" % amdgpu_build,
         "--rocm-build=%s/%s" % (job_name, build_num),
     ]
     LOG.info("Running %r" % cmd)

--- a/jax_rocm_plugin/build/rocm/tools/get_rocm.py
+++ b/jax_rocm_plugin/build/rocm/tools/get_rocm.py
@@ -96,7 +96,6 @@ UBUNTU = System(
 RHEL8 = System(
     pkgbin="dnf",
     rocm_package_list=[
-        "libdrm-amdgpu",
         "rocm-dev",
         "rocm-ml-sdk",
         "miopen-hip ",

--- a/jax_rocm_plugin/build/rocm/tools/get_rocm.py
+++ b/jax_rocm_plugin/build/rocm/tools/get_rocm.py
@@ -272,12 +272,6 @@ def setup_repos_ubuntu(rocm_version_str):
     keyadd = "wget -qO - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -"
     subprocess.check_call(keyadd, shell=True)
 
-    with open("/etc/apt/sources.list.d/amdgpu.list", "w") as fd:
-        fd.write(
-            ("deb [arch=amd64] " "https://repo.radeon.com/amdgpu/%s/ubuntu %s main\n")
-            % (rocm_version_str, codename)
-        )
-
     with open("/etc/apt/sources.list.d/rocm.list", "w") as fd:
         fd.write(
             ("deb [arch=amd64] " "https://repo.radeon.com/rocm/apt/%s %s main\n")
@@ -308,19 +302,7 @@ gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
             % rocm_version_str
         )
 
-    with open("/etc/yum.repos.d/amdgpu.repo", "w") as afd:
-        afd.write(
-            """
-[amdgpu]
-name=amdgpu
-baseurl=https://repo.radeon.com/amdgpu/%s/rhel/8.8/main/x86_64/
-enabled=1
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-"""
-            % rocm_version_str
-        )
-
+  
 
 def parse_args():
     p = argparse.ArgumentParser()


### PR DESCRIPTION
docker is already building fine without amdgpu. As such, amdgpu repo should not be framework requirement.

We are adding amdgpu repo with KMD ID and we are not using anywhere installing from this repo. ⁠
So, eventually, amdgpu part is all stale code now.

2+months before KMD is made independent and no more libdrm/mesa packages present at KMD ID repo path due to restructure.

https://osibuilds.amd.com/dashboard/#/release/488/component/3500 path of KMD ID, only amdgpu-dkms and firmware present which we eventually don't install in docker build process.

So, last 2months or so, all these code part is stale and docker is building fine and even tests are running fine.