### PR TITLE
bump up xla according to xla team's request

### DIFF
--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -21,8 +21,8 @@ load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update XLA_SHA256 with the result.
 
-XLA_COMMIT = "50860e943202307ad17ef3bc513289dfbd1b92bc"
-XLA_SHA256 = "0d8a10fc1674a347542f280c724167f1fbe7f53cc8d59f49ee5d196166c8ee0c"
+XLA_COMMIT = "efa9d45075493db1fe9f02ab80cef71ed4064ff8"
+XLA_SHA256 = "33a6e16720b60b817f294deb35d8f688875c42ffbc286b8840f1f1a270d60b5f"
 
 def repo():
     tf_http_archive(


### PR DESCRIPTION
bump up xla according to xla team's request

@charleshofer Some improvements:

TF_XLA_HSACO_BITCODE_SIZE_THRESHOLD defines bit code size threshold (set to 64K by default) deciding if a particular LLVM module shall be cached
TF_XLA_HSACO_CACHE_DIR defines a hsaco cache location (defaults to /tmp).
use flat_hash_map for in-memory hsaco cache to prevent adding duplucate entries
use ofstream read/write instead of RenameFile if hsaco cache file cannot be moved
numerous code cleanups