### PR TITLE
Add documentation on how to build rocm-jax and set up the dev env

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,227 @@
+# Building
+
+The plugin repo produces several different artifacts,
+1. JAX plugin Python wheels for ROCm (`jax_rocmX_plugin` and `jax_rocmX_pjrt`)
+2. Docker images with an installation of a JAX environment ready to use on ROCm
+3. Unit test reports on the plugin wheels
+
+All of these are produced by different commands to the `build/ci_build`
+script. This build script does nearly all of its work inside of containers.
+It requires that you have an installation of Docker and Python 3.6 or newer.
+
+# 1. Building `jax_rocmX_plugin` and `jax_rocmX_pjrt` Wheels
+
+Run the `build/ci_build` script,
+```shell
+PYTHON_VERSION="3.10,3.12"
+ROCM_VERSION=6.4.1
+
+python3 build/ci_build \
+    --python-versions="$PYTHON_VERSION" \
+    --rocm-version="$ROCM_VERSION" \
+    dist_wheels
+```
+
+You can also build with ROCm versions that are built internally at AMD by
+setting `--rocm-build-job` and `--rocm-build-num` and with your own local
+copy of XLA. For example,
+```shell
+PYTHON_VERSION="3.10,3.12"
+ROCM_VERSION=7.0.0
+ROCM_BUILD_JOB=compute-rocm-dkms-no-npi-hipclang
+ROCM_BUILD_NUM=16306
+XLA_SOURCE=~/path/to/xla
+
+python3 build/ci_build \
+    --python-versions="$PYTHON_VERSION" \
+    --rocm-version="$ROCM_VERSION" \
+    --rocm-build-job="$ROCM_BUILD_JOB" \
+    --rocm-build-num="$ROCM_BUILD_NUM" \
+    --xla-source-dir="$XLA_SOURCE" \
+    dist_wheels
+```
+
+`build/ci_build` will place your wheels inside of a wheelhouse directory.
+```shell
+ls jax_rocm_plugin/wheelhouse
+```
+If your build was successful, this should output something like,
+```shell
+jax_rocm7_pjrt-X.X.X-py3-none-manylinux_2_28_x86_64.whl
+jax_rocm7_plugin-X.X.X-cp310-cp310-manylinux_2_28_x86_64.whl
+jax_rocm7_plugin-X.X.X-cp312-cp312-manylinux_2_28_x86_64.whl
+```
+
+To install your wheels alongside `jax` and `jaxlib` in a virtual environment,
+```shell
+python -m venv .venv
+source .venv/bin/activate
+pip install -r build/requirements.txt
+pip install \
+    jax_rocm_plugin/wheelhouse/jax_rocm7_pjrt-X.X.X-py3-none-manylinux_2_28_x86_64.whl
+    jax_rocm_plugin/wheelhouse/jax_rocm7_plugin-X.X.X-cp310-cp310-manylinux_2_28_x86_64.whl
+```
+
+You may need to pass `--force-reinstall` to your `pip install` command if you
+already have an installation of the plugin packages.
+
+## Troubleshooting
+
+If you have an older version of Docker on your system, you might get an error
+about BuildKit not being installed or enabled. To fix, run
+```shell
+sudo apt-get update
+sudo apt install docker-buildx
+export DOCKER_BUILDKIT=1
+```
+
+If pip complains about wheels not being supported on your platform, check
+the version of Python in your virtual environment and make sure that your
+installing the correct plugin wheel for your Python version. 
+
+# 2. Building Docker Images
+
+Move the wheels created in section one to a wheelhouse directory, or download
+wheels from the [nightly workflow](https://github.com/ROCm/rocm-jax/actions/workflows/nightly.yml)
+and place them in the wheelhouse directory. This is where Docker will look for
+the wheels when building its images.
+```shell
+mkdir -p wheelhouse && mv jax_rocm_plugin/wheelhouse/* wheelhouse
+```
+Be mindful of what version of Python your Dockerfiles require. As of the
+writing of this guide, we currently build images for Ubuntu 22 and Ubuntu 24,
+which require Python 3.10 and Python 3.12 respectively. The kernels wheel
+(`jax_rocmX_plugin`) build builds a different wheel for each Python version.
+
+Run the build script 
+```shell
+ROCM_VERSION=6.4.1
+
+python3 build/ci_build \
+    --rocm-version=$ROCM_VERSION \
+    build_dockers
+```
+
+Like the wheel build, you can also install versions of ROCm that were built
+internally at AMD. You can also filter on the Dockerfile names in `docker/`,
+and only build images from select Dockerfiles with the `--filter` option.
+```shell
+ROCM_VERSION=7.0.0
+ROCM_BUILD_JOB=compute-rocm-dkms-no-npi-hipclang
+ROCM_BUILD_NUM=16322
+
+python3 build/ci_build \
+    --rocm-version $ROCM_VERSION \
+    --rocm-build-job $ROCM_BUILD_JOB \
+    --rocm-build-num $ROCM_BUILD_NUM \
+    build_dockers \
+    --filter ubu24
+```
+
+## Troubleshooting
+
+If your build fails with complaints about not being able to find a wheel that
+satisfies `pip`'s requirements, double-check that you have a `jax_rocmX_plugin`
+wheel in your wheelhouse directory that has been built for the version of
+Python being installed in your Docker image.
+
+# 3. Running Tests
+
+JAX ROCm plugin tests are usually run in a container via the build script,
+```shell
+TEST_IMAGE="jax-ubu24.rocm641:latest"
+python3 build/ci_build test $TEST_IMAGE --test-cmd "pytest jax_rocm_plugin/tests"
+```
+
+We keep unit tests in the `rocm/jax` repository, and you'll need to clone it
+to run the regular JAX unit tests with ROCm,
+```shell
+git clone --depth 1 --branch rocm-jaxlib-v0.6.0 git@github.com:ROCm/jax.git
+# Each release of the ROCm plugin has a corresponding branch. You can find
+# more at https://github.com/ROCm/rocm-jax/branches/all?query=rocm-jaxlib
+
+TEST_IMAGE="jax-ubu24.rocm641:latest"
+python3 build/ci_build test $TEST_IMAGE --test-cmd "pytest jax/tests"
+```
+
+Once the `rocm/jax` repo is cloned, you can also use the test scripts to run
+the full suite of JAX unit tests. These are handy because they run tests in
+parallel on systems with multiple accelerators, and they produce reports and
+logs in the `jax/logs` directory.
+```shell
+TEST_IMAGE="jax-ubu24.rocm641:latest"
+python3 build/ci_build test $TEST_IMAGE \
+    --test-cmd "python build/rocm/run_single_gpu.py -c"
+```
+or
+```shell
+TEST_IMAGE="jax-ubu24.rocm641:latest"
+python3 build/ci_build test $TEST_IMAGE \
+    --test-cmd "python build/rocm/run_multi_gpu.py -c"
+```
+
+## Dropping into the Container
+
+You can also drop into the container with an interactive shell and run tests
+that way. Create a container with the image from section two,
+```shell
+sudo docker run \
+    --name <your user ID>_rocm-jax \
+    -it \
+    --network=host \
+    --device=/dev/infiniband \
+    --device=/dev/kfd \
+    --device=/dev/dri \
+    --ipc=host \
+    --shm-size 16G \
+    --group-add video \
+    --cap-add=SYS_PTRACE \
+    --security-opt seccomp=unconfined \
+    -w /root \
+    -v <path to your rocm-jax>:/rocm-jax \
+    jax-ubu24.rocm641:latest \
+    /bin/bash
+```
+
+Once inside the container, you'll want to make sure that you have the required
+Python packages for running tests,
+```shell
+pip install -r jax_rocm_plugin/build/test-requirements.txt
+
+# Run the linear algebra tests, a set that exercises the core features of
+# the plugin.
+pytest jax/tests/linalg_test.py
+
+# Or run the single GPU script (will take quite a while)
+python jax_rocm_plugin/build/rocm/run_single_gpu.py -c
+```
+
+# How does `rocm-jax` relate to other repos?
+
+The plugin repo pulls together code from several other repositories as part of its build.
+
+### `jax-ml/jax`
+
+Pulled in [via Bazel](https://github.com/ROCm/rocm-jax/blob/master/jax_rocm_plugin/third_party/jax/workspace.bzl#L12)
+and is only used to [build the rocm_jaxX_plugin wheel](https://github.com/ROCm/rocm-jax/blob/master/jax_rocm_plugin/jaxlib_ext/tools/BUILD.bazel#L26).
+Bazel applies a [handful of patches](https://github.com/ROCm/rocm-jax/blob/master/jax_rocm_plugin/third_party/jax/workspace.bzl#L14)
+to the kernel code when it pulls jax-ml/jax. That kernel code is mostly stuff
+that we share with Nvidia, changes to it from AMD are few and far in-between,
+and changes almost always make their way into `jax-ml/jax` at some point, at
+which we can remove the patch file.
+
+### `rocm/xla`
+
+Also pulled in [via Bazel](https://github.com/ROCm/rocm-jax/blob/master/jax_rocm_plugin/third_party/xla/workspace.bzl)
+and is used to build the PJRT wheel (`jax_rocmX_pjrt`). XLA is a compiler
+that turns operations in JAX Python code into kernels that can be run on
+an AMD GPU. This happens via the PJRT interface.
+
+### `rocm/jax`
+
+Only used for test cases and staging PRs from AMD developers into
+jax-ml/jax. Mostly, this is storing test cases that we skip because we have
+yet to fix the underlying bug, and we'll eventually unskip that test case
+when it gets fixed.
+
+

--- a/DEVSETUP.md
+++ b/DEVSETUP.md
@@ -1,0 +1,202 @@
+# Development Setup
+
+A more advanced setup for developers who want an environment where they can
+configure their plugin build, run tests, build their own `jax` or `jaxlib`
+wheels, and iterate more quickly than possible with the full manylinux build.
+
+If all you want is a build of the ROCm JAX plugins using your own local copy
+of XLA, it will probably be much easier for you to use the `build/ci_build`
+script as described in the [README's Quickbuild section](README.md#Quickbuild).
+
+The `stack.py` script is there to help developers set up their environment. It
+has two commands,
+
+  - `docker` that will create an Ubuntu docker container with ROCm, Clang, and
+    other needed dev too
+  - `develop` that clones the `rocm/jax` and `rocm/xla` repositories, used for
+    running unit tests and building with different branches or local changes
+    to XLA, and creates `jax_rocm_plugin/Makefile` that developers can use to
+    build and install the plugin and jaxlib wheels. They are encouraged to
+    modify the Makefile to fit their specific build requirements.
+
+# Setting up a Docker Development Environment
+
+Development on the plugin is usually done in a Docker container environment
+to isolate it from host systems, and allow developers to use different versions
+of ROCm, CPython, and other system libraries while developing.
+
+Run stack.py to create a container and drop into it with a shell,
+```shell
+python3 stack.py docker
+```
+It will take a few minutes to set up.
+
+Run stack.py again to create a Makefile and clone the `rocm/xla` and
+`rocm/jax` repositories,
+```shell
+python3 stack.py develop --rebuild-makefile
+cat jax_rocm_plugin/Makefile
+```
+
+Congratulations! You're all set up to start developing the ROCm JAX plugins.
+If you're new, you should take some time to familiarize yourself with the
+build targets in the Makefile. Trace them down into the `build/build.py`
+script and the Bazel targets that it runs.
+
+## The Makefile
+
+Developers are expected to modify the Makefile in `jax_rocm_plugin` to fit
+their build and debugging requirements. `stack.py` gives you a handful of
+targets,
+
+  - `jax_rocm_plugin` will build the kernels plugin wheel
+  - `jax_rocm_pjrt` will build the PJRT plugin wheel
+  - `dist` will build both wheels and stick them in the `dist/` directory
+  - `install` will install the wheels in `dist/` with `pip`
+  - `test` runs the basic plugin unit tests
+  - `clean` will delete all wheels in `dist/`
+
+To build and install the plugins in your virtual environment, run
+```shell
+source .venv/bin/activate
+make clean dist install
+```
+
+If you run `pip list | grep jax`, you should now be able to see the plugin
+wheels in your Python environment, along with the `jax` and `jaxlib` wheels.
+
+You can run the tests in `jax_rocm_plugin/tests` with,
+```shell
+make test
+```
+
+### Building PJRT with Local XLA
+
+By default, the Makefile is set up to build with the local copy of XLA cloned
+into the top-level of the `rocm-jax` repo. You can modify the `jax_rocm_pjrt`
+target to use a different XLA,
+```shell
+jax_rocm_pjrt:
+        python3 ./build/build.py build \
+            --use_clang=true \
+            --wheels=jax-rocm-pjrt \
+            --rocm_path=/opt/rocm/ \
+            --rocm_version=7 \
+            --rocm_amdgpu_targets=${AMDGPU_TARGETS} \
+            --bazel_options="--override_repository=xla=path/to/my/copy/of/xla" \
+            --verbose \
+            --clang_path=/usr/lib/llvm-18/bin/clang
+```
+
+Alternatively, if you have a branch in the `rocm/xla` or upstream XLA repo
+that you want to use, you can fetch it with `git` from inside of the XLA clone
+sitting at the top-level of the `rocm-jax` repo,
+```shell
+cd ../xla
+
+# Use a branch in rocm/xla
+git fetch origin
+git checkout my-xla-feature-branch
+
+# Use upstream's main branch
+git remote add upstream git@github.com:openxla/xla.git
+git fetch upstream
+git checkout upstream/main
+```
+
+You can then rebuild and re-install your wheels with,
+```shell
+source .venv/bin/activate
+(cd ./jax_rocm_plugin && make clean dist install)
+```
+
+### Building Kernels and their Bindings with Local JAX
+
+The kernels wheel (`jax_rocmX_plugin`), contains several kernels along with
+the C++/Python bindings that `jaxlib` uses to launch them. The code for the
+kernels and their bindings lives in the upstream JAX repo, `jax-ml/jax`, and
+is split between `jaxlib/gpu` and `jaxlib/rocm`. Normally, we pull this repo
+in [via Bazel](https://github.com/ROCm/rocm-jax/blob/master/jax_rocm_plugin/third_party/jax/workspace.bzl#L12).
+
+You  might want to use your local copy of `jax` in the repo's top-level to
+fix a bug in the kernels or bindings. You can modify the `jax_rocm_plugin`
+target to do this with a `--bazel_options` flag, similar to how we might do
+this for a local copy of XLA,
+```shell
+jax_rocm_plugin:
+        python3 ./build/build.py build \
+            --use_clang=true \
+            --wheels=jax-rocm-plugin \
+            --rocm_path=/opt/rocm/ \
+            --rocm_version=7 \
+            --rocm_amdgpu_targets=${AMDGPU_TARGETS} \
+            --bazel_options="--override_repository=xla=../xla" \
+            --bazel_options="--override_repository=jax=../jax" \
+            --verbose \
+            --clang_path=/usr/lib/llvm-18/bin/clang
+```
+
+The code in `jaxlib/gpu` tends to change frequently, so it's a good idea to
+make sure that your local copy of `jax` is pointed at the JAX release that
+we are currently targeting for next release (or the release you're fixing the
+bug for),
+```shell
+cd ../jax
+
+git remote add upstream git@github.com:jax-ml/jax.git
+git fetch upstream
+git checkout upstream/release/X.X.X
+```
+
+## Manual Setup
+
+You can also set up your environment command-by-command.
+
+Create a fresh ubuntu 22.04 container
+```
+sudo docker run -it --network=host \
+    --device=/dev/kfd \
+    --device=/dev/dri \
+    --ipc=host \
+    --shm-size 16G \
+    --group-add video \
+    --cap-add=SYS_PTRACE \
+    --security-opt seccomp=unconfined \
+    --rm \
+    -v ./:/rocm-jax \
+    ubuntu:22.04
+```
+
+### Docker Setup Script
+
+Use the docker setup script in tools to set up your environment.
+
+```
+cd /rocm-jax
+bash tools/docker_dev_setup.sh
+```
+
+This will do the following
+  - Install system deps with apt-get
+  - Install clang-18
+  - Install ROCm
+  - Create a python virtualenv for JAX + python packages
+
+
+After this you should re-run stack.py develop to rebuild your makefile
+```
+python stack.py develop --rebuild-makefile
+```
+
+Activate the virtual environment
+```shell
+source .venv/bin/activate
+```
+and build and install the wheels
+```shell
+(cd jax_rocm_plugin && make clean dist install)
+```
+
+You can fully customize your setup by modifying the 
+`tools/docker_dev_setup.sh` script, or doing its steps manually.
+

--- a/README.md
+++ b/README.md
@@ -3,203 +3,19 @@
 [![CI](https://github.com/ROCm/rocm-jax/actions/workflows/ci.yml/badge.svg?branch=master&event=push)](https://github.com/ROCm/rocm-jax/actions/workflows/ci.yml)
 [![Nightly](https://github.com/ROCm/rocm-jax/actions/workflows/nightly.yml/badge.svg)](https://github.com/ROCm/rocm-jax/actions/workflows/nightly.yml)
 
-`rocm-jax` contains sources for the ROCm plugin for JAX, as well as Dockerfiles used to build AMDs `rocm/jax` images.
-
-# development setup
-
-Run stack.py develop to clone jax/xla
-```
-python stack.py develop
-```
-
-Create a fresh ubuntu 22.04 container
-```
-sudo docker run -it --network=host \
-    --device=/dev/kfd \
-    --device=/dev/dri \
-    --ipc=host \
-    --shm-size 16G \
-    --group-add video \
-    --cap-add=SYS_PTRACE \
-    --security-opt seccomp=unconfined \
-    --rm \
-    -v ./:/rocm-jax \
-    ubuntu:22.04
-```
-
-## Docker environment setup
-
-Development on the plugin is usually done in a Docker container environment
-to isolate it from host systems, and allow developers to use different versions
-of ROCm, CPython, and other system libraries while developing.
-
-There are two options for setting up your Docker environment.
-
-### Option 1 - docker setup script
-
-Use the docker setup script in tools to set up your environment.
-
-```
-cd /rocm-jax
-bash tools/docker_dev_setup.sh
-```
-
-This will do the following
-  - Install system deps with apt-get
-  - Install clang-18
-  - Install ROCm
-  - Create a python virtualenv for JAX + python packages
-
-
-After this you should re-run stack.py develop to rebuild your makefile
-```
-python stack.py develop --rebuild-makefile
-```
-
-Now you can build the plugin
-```
-(cd jax_rocm_plugin && make clean dist)
-```
-
-To activate the virtual environment, run the following:
-```
-source .venv/bin/activate
-```
-
-To install the newly built plugin wheels, run the following command:
-```
-pip install jax_rocm_plugin/dist/*.whl
-```
-
-
-### Option 2 - manual docker setup
-
-Install system deps
-```
-apt-get update
-apt-get install -y \
-  python3 \
-  python-is-python3 \
-  wget \
-  curl \
-  vim \
-  build-essential \
-  make \
-  patchelf \
-  python3.10-venv \
-  lsb-release \
-  cmake \
-  yamllint \
-  shellcheck
-```
-
-Install clang
-```
-mkdir -p /tmp/llvm-project
-
-[[ -e /tmp/llvm-project/README.md ]] || wget -O - https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-18.1.8.tar.gz | tar -xz -C /tmp/llvm-project --strip-components 1
-
-mkdir -p /tmp/llvm-project/build
-pushd /tmp/llvm-project/build
-
-cmake -DLLVM_ENABLE_PROJECTS='clang;lld' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-18/ ../llvm
-
-make -j$(nproc) && make -j$(nproc) install && rm -rf /tmp/llvm-project
-
-popd
-```
-
-Install ROCm
-```
-cd /rocm-jax
-python build/tools/get_rocm.py --rocm-version 6.4.0
-```
-
-Create a virtualenv and activate it
-```
-python -m venv .venv
-. .venv/bin/activate
-```
-
-Install dependencies
-```
-pip install -r build/requirements.txt
-```
-
-If using ROCm version >= 7, apply necessary patch for namespace change
-```
-patch -p1 \
-    -d "$(python3 -c \"import sysconfig; print(sysconfig.get_paths()['purelib'])\")" \
-    < jax_rocm_plugin/third_party/jax/namespace.patch
-
-```
-
-Run stack.py to refresh your local Makefile for the docker env
-```
-python stack.py develop --rebuild-makefile
-```
-
-Use make to build the plugin
-```
-(cd jax_rocm_plugin && make clean dist)
-```
-
-# Unit Testing Setup
-
-Clone the repository
-```
-git clone https://github.com/ROCm/rocm-jax.git && cd rocm-jax
-```
-
-Build manylinux wheels
-```
-python3 build/ci_build --compiler=clang --python-versions="3.10" --rocm-version=7.0.0 --rocm-build-job="compute-rocm-dkms-no-npi-hipclang" --rocm-build-num="16306" dist_wheels
-```
-
-If you have BuildKit error:
-```
-sudo apt-get update
-sudo apt install docker-buildx
-export DOCKER_BUILDKIT=1
-```
-
-Move the created wheels to wheelhouse directory
-```
-mkdir -p wheelhouse && mv jax_rocm_plugin/wheelhouse/* ./wheelhouse/
-```
-
-Create docker image
-```
-python3 build/ci_build --rocm-version=7.0.0 --rocm-build-job="compute-rocm-dkms-no-npi-hipclang" --rocm-build-num="16306" build_dockers --filter=ubu22
-```
-
-Create container with the image created in the previous step
-```
-alias drun='sudo docker run --name <yourID>_rocm-jax -it --network=host  --device=/dev/infiniband --device=/dev/kfd --device=/dev/dri --ipc=host --shm-size 16G --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -w /root -v /home/<yourID>/rocm-jax:/rocm-jax'
-drun jax-ubu22.rocm700 OR drun <docker image id or name of the image step 5 produced>
-```
-
-To test UTs:
-```
-apt-get install -y vim git
-cd /rocm-jax
-python stack.py develop
-
-cd jax
-pip install -r build/test-requirements.txt && pip install -r build/rocm-test-requirements.txt
-python ./build/rocm/run_single_gpu.py -c 2>&1 | tee 0.6.0_ut.log
-```
+`rocm-jax` contains sources for the ROCm plugin for JAX, as well as Dockerfiles used to build AMD's `rocm/jax` images.
 
 
 # Nightly Builds
 
 We build rocm-jax nightly with [a Github Actions workflow](https://github.com/ROCm/rocm-jax/actions/workflows/nightly.yml).
 
-## Docker
+## Docker Images
 
-Nightly docker images are kept in the Github Container Registry
+Using our Docker images is by far the simplest way to run JAX on ROCm.
+Nightly Docker images are kept in the Github Container Registry
 
-```
+```shell
 echo <MY_GITHUB_ACCESS_TOKEN> | docker login ghcr.io -u <USERNAME> --password-stdin
 docker pull ghcr.io/rocm/jax-ubu24.rocm70:nightly
 ```
@@ -214,11 +30,77 @@ Once your token has been created, go back to the Tokens (classic) page and set y
 
 Once your token has been set up to use SSO, you can log in with the `docker` command line by running,
 
-```
+```shell
 echo <MY_GITHUB_ACCESS_TOKEN> | docker login ghcr.io -u <USERNAME> --password-stdin
 ```
 
 ## Wheels
 
 Wheels get saved as artifacts to each run of the nightly workflow. Go to the [nightly workflow](https://github.com/ROCm/rocm-jax/actions/workflows/nightly.yml), select the run you want to get wheels from, and scroll down to the bottom of the page to find the build artifacts. Each artifact is a zip file that contains all of the wheels built for a specific ROCm version.
+
+
+# Building and Testing Yourself
+
+More complete build instructions can be [found here](BUILDING.md).
+
+## Quickbuild
+
+```shell
+PYTHON_VERSION=3.12
+ROCM_VERSION=6.4.1
+
+# Clear out old builds
+rm -f jax_rocm_plugin/wheelhouse/*
+rm -f wheelhouse/*
+
+# Build the wheels
+python3 build/ci_build \
+    --python-version $PYTHON_VERSION \
+    --rocm-version $ROCM_VERSION \
+    dist_wheels
+
+# Move the wheels to the wheelhouse
+mkdir -p wheelhouse
+cp jax_rocm_plugin/wheelhouse/* wheelhouse
+
+# Build the Docker image for Ubuntu 24
+python3 build/ci_build \
+    --python-version $PYTHON_VERSION \
+    --rocm-version $ROCM_VERSION \
+    build_dockers \
+    --filter 24
+
+# Run basic tests
+build/ci_build test jax-ubu24.rocm641:latest \
+    --test-cmd "pytest jax_rocm_plugin/tests"
+```
+
+## Using a Local Copy of XLA
+
+You can build the `jax_rocmX_pjrt` wheel with your local copy of XLA by
+supplying a `--xla-source-dir` argument to the build script when you build
+the wheels,
+```shell
+python3 build/ci_build \
+    --python-version $PYTHON_VERSION \
+    --rocm-version $ROCM_VERSION \
+    --xla-source-dir <PATH TO MY XLA REPO> \
+    dist_wheels
+```
+
+# Development Setup
+
+For more detailed instructions on how to set up your development environment,
+see the [dev setup guide](DEVSETUP.md).
+
+## Quickstart
+
+```shell
+python3 stack.py docker
+```
+
+Once inside the container,
+```shell
+python3 stack.py develop --rebuild-makefile
+```
 


### PR DESCRIPTION
Streamlined the README so that it only includes quick descriptions of how to build rocm-jax and how to set up the dev environment. It also re-orders the sections. Here's hoping that by putting the section on using the nightly build first, more customers will use that and less will build it themselves. Adds two new documents, one that goes in depth on how to build with the manylinux wheel, and one that goes in depth on how to set up and modify your development environment.