### PR TITLE
Single-GPU UT script path fix 

### DIFF
--- a/jax_rocm_plugin/build/rocm/run_single_gpu.py
+++ b/jax_rocm_plugin/build/rocm/run_single_gpu.py
@@ -166,7 +166,6 @@ def collect_testmodules(ignore_skipfile):
             normalized_path = relative_path
 
         if normalized_path not in MULTI_GPU_TESTS:
-            print("---------------", test_file, "normalized", normalized_path)
             filtered_test_files.add(test_file)
         else:
             excluded_count += 1


### PR DESCRIPTION
## Motivation

Fixed a missing path snippet that was causing test not found error.

## Technical Details

The parse_test_log function was adding "jax" directory preappended to the modules when it was returning collected test modules. This was causing test not found error, because it should be jax/tests preappended. This PR fixes that. 

## Test Plan
Tested using harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16683_ubuntu24.04_py3.12_jax_master_48d1947

## Test Result
Tests started running fine. 

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
