### PR TITLE
Updated XLA pinned version

### DIFF
--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -16,8 +16,8 @@ load("//third_party:repo.bzl", "amd_http_archive")
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update XLA_SHA256 with the result.
 
-XLA_COMMIT = "104647d7abd13d81b9050184ababa3154563eef5"
-XLA_SHA256 = "6f873c30e15e8644bd42a1856681f07a2457fdf0ec2f3109c52803aa53f6963d"
+XLA_COMMIT = "74b4b8dedc12565e98cfb8383ae29305980eb39a"
+XLA_SHA256 = "5d7511b3d54fd1d22f317b3708e1467faf105f10a617980f079a162808235bf1"
 
 def repo():
     amd_http_archive(


### PR DESCRIPTION
## Motivation

Updated XLA pinned version to commit -id 74b4b8dedc12565e98cfb8383ae29305980eb39a.
Currently, this is tip of rocm/xla branch rocm-jaxlib-v0.7.1. 
This contains all the fixes/updates ported from rocm/xla branch rocm-jaxlib.v0.6.0

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Unit test is test plan for this change.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Local test passed.

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
