### PR TITLE
Added jaxlib wheel build infrastructure and included it in docker-images

### DIFF
--- a/docker/Dockerfile.jax-ubu22
+++ b/docker/Dockerfile.jax-ubu22
@@ -96,4 +96,5 @@ LABEL com.amdgpu.rocm_version="$ROCM_VERSION" \
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     --mount=type=bind,source=wheelhouse,target=/wheelhouse \
     ls -lah /wheelhouse && \
-    pip3 install -f /wheelhouse --no-deps --no-index "jax_rocm${PLUGIN_NAMESPACE}_plugin" "jax_rocm${PLUGIN_NAMESPACE}_pjrt"
+    pip3 install -f /wheelhouse --no-deps --no-index "jax_rocm${PLUGIN_NAMESPACE}_plugin" "jax_rocm${PLUGIN_NAMESPACE}_pjrt" && \
+    pip3 install -f /wheelhouse --no-deps --no-index --force-reinstall "jaxlib"

--- a/docker/Dockerfile.jax-ubu24
+++ b/docker/Dockerfile.jax-ubu24
@@ -82,4 +82,5 @@ LABEL com.amdgpu.rocm_version="$ROCM_VERSION" \
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     --mount=type=bind,source=wheelhouse,target=/wheelhouse \
     ls -lah /wheelhouse && \
-    pip3 install -f /wheelhouse --no-deps --no-index "jax_rocm${PLUGIN_NAMESPACE}_plugin" "jax_rocm${PLUGIN_NAMESPACE}_pjrt"
+    pip3 install -f /wheelhouse --no-deps --no-index "jax_rocm${PLUGIN_NAMESPACE}_plugin" "jax_rocm${PLUGIN_NAMESPACE}_pjrt" && \
+    pip3 install -f /wheelhouse --no-deps --no-index --force-reinstall "jaxlib"

--- a/jax_rocm_plugin/build/rocm/build_wheels/Dockerfile.manylinux_2_28_x86_64.rocm
+++ b/jax_rocm_plugin/build/rocm/build_wheels/Dockerfile.manylinux_2_28_x86_64.rocm
@@ -7,7 +7,11 @@ ARG THEROCK_PATH
 
 # Install system GCC and C++ libraries, and build deps
 RUN --mount=type=cache,target=/var/cache/dnf \
-    dnf install -y patchelf numactl-devel
+    dnf install -y patchelf numactl-devel python3.11 python3.11-devel python3.11-pip && \
+    rm -f /usr/bin/python3 && ln -sf /usr/bin/python3.11 /usr/bin/python3 && \
+    rm -f /usr/bin/pip3 && ln -sf /usr/bin/pip3.11 /usr/bin/pip3 && \
+    python3.11 -m pip install --upgrade pip setuptools wheel
+
 
 RUN --mount=type=cache,target=/var/cache/dnf \
     --mount=type=bind,source=build/rocm/tools/get_rocm.py,target=get_rocm.py \

--- a/jax_rocm_plugin/build/rocm/ci_build
+++ b/jax_rocm_plugin/build/rocm/ci_build
@@ -24,7 +24,43 @@ import argparse
 import os
 import subprocess
 import sys
+import shutil
 
+def build_jaxlib_wheel(rocm_version, pyver_string):
+
+    JAX_BRANCH = "rocm-jaxlib-v0.7.1"
+    JAX_URL = f"https://github.com/ROCm/jax/archive/refs/heads/{JAX_BRANCH}.tar.gz"
+    TARGET_DIR = os.path.abspath("./wheelhouse/jax_repo")
+
+    try:
+        os.makedirs(TARGET_DIR, exist_ok=True)
+        subprocess.check_call(["bash", "-c", f"curl -L {JAX_URL} | tar -xz -C {TARGET_DIR} --strip-components=1"])
+    
+    except subprocess.CalledProcessError as e:
+        print(f"[ERROR] Command failed with exit code {e.returncode}")
+        sys.exit(e.returncode)
+
+    except FileNotFoundError:
+        print(f"[ERROR] Directory not found: {TARGET_DIR}")
+        sys.exit(1)
+
+    py_versions = [float(x) for x in pyver_string.split(",")]
+    cmd=["&&", "pushd", "/wheelhouse/jax_repo", "&&"]
+
+    for py_ver in py_versions:
+        cmd += [
+            "python3.11", "./build/build.py", "build",
+            "--wheels=\"jaxlib\"",
+            "--rocm_version=7",
+            f"--python_version=\"{py_ver}\"",
+            f"--rocm_path=/opt/rocm-{rocm_version}",
+            f"--clang_path=/opt/rocm-{rocm_version}/llvm/bin/clang",
+            "--output_path=/wheelhouse", "&&",
+            ]
+
+    cmd += ["popd", "&&",  "rm -rf /wheelhouse/jax_repo",]
+    print(f"jaxlib-wheel-cmd={cmd}")
+    return cmd
 
 def image_by_name(name):
     cmd = ["docker", "images", "-q", "-f", "reference=%s" % name]
@@ -102,6 +138,7 @@ def dist_wheels(
         bw_cmd.extend(["--xla-path", container_xla_path])
 
     bw_cmd.append("/jax")
+    bw_cmd = bw_cmd + build_jaxlib_wheel(rocm_version, pyver_string)
 
     cmd = ["docker", "run"]
 
@@ -138,6 +175,7 @@ def dist_wheels(
         ]
     )
 
+    print(f"final-build-wheel-cmd={cmd}")
     _ = subprocess.run(cmd, check=True)
 
 


### PR DESCRIPTION
## Motivation

we need to release "jaxlib" in rocm7.1 release, UT tests fell into dormant state while running in parallel, processes occupy memory but CUs are not utilized, this is happening in sparse test. reason is not able to handle correctly address  pool singleton sharing between GPUs. (NOTE: running one by one (in sequential manner) results in test passed)


<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

These are the upstream PRs, one is merged and other one is in review. However merged one is not included in 7.1 release.
https://github.com/jax-ml/jax/pull/30715 Merged after release/0.7.1 branch
https://github.com/jax-ml/jax/pull/31937/ not merged yet.

## Test Plan
JAX UTs

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
single gpu tests passed running in parallel in different GPU, not falling into dormant process state.

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
