### PR TITLE
Update workflows (ci, and nightly) for ROCm 7.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: mi-250
     strategy:
       matrix:
-        rocm-version: ["7.0.0"]
+        rocm-version: ["7.0.2"]
     steps:
       - name: Change owners for cleanup
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,9 +34,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rocm-version: ["7.0.0", "7.1.0"]
+        rocm-version: ["7.0.2", "7.1.0"]
         include:
-          - rocm-version: "7.0.0"
+          - rocm-version: "7.0.2"
             runner-label: "mi-250"
           - rocm-version: "7.1.0"
             rocm-build-job: "compute-rocm-dkms-no-npi-hipclang"
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rocm-version: ["7.0.0", "7.1.0"]
+        rocm-version: ["7.0.2", "7.1.0"]
         ubuntu-version: ["22", "24"]
     steps:
       - name: Change owners for cleanup
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rocm-version: ["7.0.0", "7.1.0"]
+        rocm-version: ["7.0.2", "7.1.0"]
         ubuntu-version: ["22", "24"]
     steps:
       - name: Checkout source


### PR DESCRIPTION
This PR updates ci and nightly workflows with the ROCm 7.0.2 release. 