### PR TITLE
Add explicit permissions for nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   call-build-wheels:
     strategy:


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

I thought that this might be related to our permissions problems with images not being pulled from GHCR, but that is not the case since images are now pulling just fine. Anyways, it's good practice for workflows to explicitly state the permissions that they need, so we should still add this.

## Technical Details

Adds permissions that the nightly build job needs so that we don't rely on GITHUB_TOKEN's defaults: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions

## Test


