### PR TITLE
updated xla commit on repo rocm/xla -  rocm-jaxlib-v0.7.1 branch

### DIFF
--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -16,8 +16,8 @@ load("//third_party:repo.bzl", "amd_http_archive")
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update XLA_SHA256 with the result.
 
-XLA_COMMIT = "74b4b8dedc12565e98cfb8383ae29305980eb39a"
-XLA_SHA256 = "5d7511b3d54fd1d22f317b3708e1467faf105f10a617980f079a162808235bf1"
+XLA_COMMIT = "2e5971172f0c0d8f3a4c37b55cc1b53b4ec37cae"
+XLA_SHA256 = "4c31305acad30da49740ab78670ba2699ba45f4a01c4fdc9a5e32e60f9933509"
 
 def repo():
     amd_http_archive(


### PR DESCRIPTION
## Motivation

Bumping up XLA commit to tip of branch rocm-jaxlib-v0.7.1 on rocm/xla. This PR is backporting upstream feature that we can directly run hlo in python script, wouldn't do any performance improvement, but nice to have it...!  customers can directly use python script to run dump out hlo, otherwise this is a broken feature in our side but working on NV side

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
jax unit test

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Unit test passed

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
