### PR TITLE
Fix build number for DLM performance CI and update for JAX 0.7.1

### DIFF
--- a/.github/workflows/rocm-perf.yml
+++ b/.github/workflows/rocm-perf.yml
@@ -91,6 +91,8 @@ jobs:
 
       - name: Run MaxText training and save logs
         run: |
+          docker exec maxtext_container bash -c \
+            "apt update && apt install -y libdw1"
           for config in \
             MaxText/configs/models/gpu/llama2_7b_rocm.yml \
             MaxText/configs/models/gpu/gemma_2b_rocm.yml \


### PR DESCRIPTION
This PR fix the build number for DLM performance CI to correctly update for JAX 0.7.1 & ROCm 7.0+. Minimal changes applied to MaxText branch such as relaxing pin requirements.