### PR TITLE
Adding rpath for /opt/rocm/libs since librccl.so etc is not found (#135)

### DIFF
--- a/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Script that builds a jax-rocm-plugin wheel for ROCm kernels.
+# Most users should not run this script directly; use build.py instead.
+# pylint: disable=duplicate-code
 
-This script is intended to be run via bazel run as part of the JAX ROCm plugin
-build process. Most users should not run this script directly; use build.py instead.
+"""
+Script to build a JAX ROCm kernel plugin wheel. Intended for use via Bazel.
 """
 
 import argparse
@@ -32,6 +33,12 @@ from bazel_tools.tools.python.runfiles import runfiles
 from jaxlib_ext.tools import build_utils
 
 parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--sources_path",
+    default=None,
+    help="Path in which the wheel's sources should be prepared. Optional. If "
+    "omitted, a temporary directory will be used.",
+)
 parser.add_argument(
     "--output_path",
     default=None,
@@ -98,7 +105,7 @@ parser.add_argument(
 args = parser.parse_args()
 
 r = runfiles.Create()
-pyext = "pyd" if build_utils.is_windows() else "so"
+PYEXT = "pyd" if build_utils.is_windows() else "so"
 
 
 def write_setup_cfg(setup_sources_path, cpu):
@@ -159,14 +166,14 @@ def prepare_wheel_rocm(wheel_sources_path: pathlib.Path, *, cpu, rocm_version):
     copy_runfiles(
         dst_dir=plugin_dir,
         src_files=[
-            f"jax/jaxlib/rocm/_linalg.{pyext}",
-            f"jax/jaxlib/rocm/_prng.{pyext}",
-            f"jax/jaxlib/rocm/_solver.{pyext}",
-            f"jax/jaxlib/rocm/_sparse.{pyext}",
-            f"jax/jaxlib/rocm/_hybrid.{pyext}",
-            f"jax/jaxlib/rocm/_rnn.{pyext}",
-            f"jax/jaxlib/rocm/_triton.{pyext}",
-            f"jax/jaxlib/rocm/rocm_plugin_extension.{pyext}",
+            f"jax/jaxlib/rocm/_linalg.{PYEXT}",
+            f"jax/jaxlib/rocm/_prng.{PYEXT}",
+            f"jax/jaxlib/rocm/_solver.{PYEXT}",
+            f"jax/jaxlib/rocm/_sparse.{PYEXT}",
+            f"jax/jaxlib/rocm/_hybrid.{PYEXT}",
+            f"jax/jaxlib/rocm/_rnn.{PYEXT}",
+            f"jax/jaxlib/rocm/_triton.{PYEXT}",
+            f"jax/jaxlib/rocm/rocm_plugin_extension.{PYEXT}",
             "jax/jaxlib/version.py",
         ],
     )
@@ -189,16 +196,16 @@ def prepare_wheel_rocm(wheel_sources_path: pathlib.Path, *, cpu, rocm_version):
         raise RuntimeError(mesg) from ex
 
     files = [
-        f"_linalg.{pyext}",
-        f"_prng.{pyext}",
-        f"_solver.{pyext}",
-        f"_sparse.{pyext}",
-        f"_hybrid.{pyext}",
-        f"_rnn.{pyext}",
-        f"_triton.{pyext}",
-        f"rocm_plugin_extension.{pyext}",
+        f"_linalg.{PYEXT}",
+        f"_prng.{PYEXT}",
+        f"_solver.{PYEXT}",
+        f"_sparse.{PYEXT}",
+        f"_hybrid.{PYEXT}",
+        f"_rnn.{PYEXT}",
+        f"_triton.{PYEXT}",
+        f"rocm_plugin_extension.{PYEXT}",
     ]
-    runpath = "$ORIGIN/../rocm/lib:$ORIGIN/../../rocm/lib"
+    runpath = "$ORIGIN/../rocm/lib:$ORIGIN/../../rocm/lib:/opt/rocm/lib"
     # patchelf --force-rpath --set-rpath $RUNPATH $so
     for f in files:
         so_path = os.path.join(plugin_dir, f)
@@ -207,30 +214,42 @@ def prepare_wheel_rocm(wheel_sources_path: pathlib.Path, *, cpu, rocm_version):
         if not perms & stat.S_IWUSR:
             fix_perms = True
             os.chmod(so_path, perms | stat.S_IWUSR)
-        subprocess.check_call(
-            ["patchelf", "--force-rpath", "--set-rpath", runpath, so_path]
-        )
+        subprocess.check_call(["patchelf", "--set-rpath", runpath, so_path])
         if fix_perms:
             os.chmod(so_path, perms)
 
 
-tmpdir = tempfile.TemporaryDirectory(prefix="jax_rocm_plugin")
-sources_path = tmpdir.name
-try:
-    os.makedirs(args.output_path, exist_ok=True)
-    prepare_wheel_rocm(
-        pathlib.Path(sources_path), cpu=args.cpu, rocm_version=args.platform_version
-    )
-    package_name = f"jax rocm{args.platform_version} plugin"
-    if args.editable:
-        build_utils.build_editable(sources_path, args.output_path, package_name)
-    else:
-        git_hash = build_utils.get_githash(args.rocm_jax_git_hash)
-        build_utils.build_wheel(
-            sources_path,
-            args.output_path,
-            package_name,
-            git_hash=git_hash,
-        )
-finally:
-    tmpdir.cleanup()
+def main():
+    """Main entry point for building the ROCm plugin wheel."""
+    sources_path = args.sources_path
+    with tempfile.TemporaryDirectory(prefix="jax_rocm_plugin") as tmpdir:
+
+        if sources_path is None:
+            sources_path = tmpdir
+
+        os.makedirs(args.output_path, exist_ok=True)
+
+        if args.enable_rocm:
+            prepare_wheel_rocm(
+                pathlib.Path(sources_path),
+                cpu=args.cpu,
+                rocm_version=args.platform_version,
+            )
+            package_name = f"jax rocm{args.platform_version} plugin"
+        else:
+            raise ValueError("Unsupported backend. Choose 'rocm'.")
+
+        if args.editable:
+            build_utils.build_editable(sources_path, args.output_path, package_name)
+        else:
+            git_hash = build_utils.get_githash(args.rocm_jax_git_hash)
+            build_utils.build_wheel(
+                sources_path,
+                args.output_path,
+                package_name,
+                git_hash=git_hash,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
+++ b/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Script that builds a jax-rocm-plugin wheel for ROCm kernels.
+# Most users should not run this script directly; use build.py instead.
+# pylint: disable=duplicate-code
 
-This script is intended to be run via bazel run as part of the JAX ROCm plugin
-build process. Most users should not run this script directly; use build.py instead.
+"""
+Script to build a JAX ROCm plugin wheel. Intended for use via Bazel.
 """
 
 import argparse
@@ -26,7 +27,7 @@ import stat
 import subprocess
 import tempfile
 
-# pylint: disable=import-error,invalid-name,consider-using-with
+# pylint: disable=import-error
 from bazel_tools.tools.python.runfiles import runfiles
 from pjrt.tools import build_utils
 
@@ -99,11 +100,10 @@ args = parser.parse_args()
 r = runfiles.Create()
 
 
-def write_setup_cfg(setup_sources_path, cpu):
+def write_setup_cfg(setup_cfg_path, cpu):
     """Write setup.cfg file for wheel build."""
     tag = build_utils.platform_tag(cpu)
-    cfg_path = setup_sources_path / "setup.cfg"
-    with open(cfg_path, "w", encoding="utf-8") as f:
+    with open(setup_cfg_path / "setup.cfg", "w", encoding="utf-8") as f:
         f.write(
             f"""[metadata]
 license_files = LICENSE.txt
@@ -182,47 +182,49 @@ def prepare_rocm_plugin_wheel(wheel_sources_path: pathlib.Path, *, cpu, rocm_ver
         raise RuntimeError(mesg) from ex
 
     shared_obj_path = os.path.join(plugin_dir, "xla_rocm_plugin.so")
-    runpath = "$ORIGIN/../rocm/lib:$ORIGIN/../../rocm/lib"
+    runpath = "$ORIGIN/../rocm/lib:$ORIGIN/../../rocm/lib:/opt/rocm/lib"
     # patchelf --force-rpath --set-rpath $RUNPATH $so
     fix_perms = False
     perms = os.stat(shared_obj_path).st_mode
     if not perms & stat.S_IWUSR:
         fix_perms = True
         os.chmod(shared_obj_path, perms | stat.S_IWUSR)
-    subprocess.check_call(
-        ["patchelf", "--force-rpath", "--set-rpath", runpath, shared_obj_path]
-    )
+    subprocess.check_call(["patchelf", "--set-rpath", runpath, shared_obj_path])
     if fix_perms:
         os.chmod(shared_obj_path, perms)
 
 
-tmpdir = None
-sources_path = args.sources_path
-if sources_path is None:
-    tmpdir = tempfile.TemporaryDirectory(prefix="jaxgpupjrt")
-    sources_path = tmpdir.name
+def main():
+    """Main entry point for building the ROCm plugin wheel."""
+    sources_path = args.sources_path
+    with tempfile.TemporaryDirectory(prefix="jaxgpupjrt") as tmpdir:
 
-try:
-    os.makedirs(args.output_path, exist_ok=True)
+        if sources_path is None:
+            sources_path = tmpdir
 
-    if args.enable_rocm:
-        prepare_rocm_plugin_wheel(
-            pathlib.Path(sources_path), cpu=args.cpu, rocm_version=args.platform_version
-        )
-        package_name = "jax rocm plugin"
-    else:
-        raise ValueError("Unsupported backend. Choose 'rocm'.")
+        os.makedirs(args.output_path, exist_ok=True)
 
-    if args.editable:
-        build_utils.build_editable(sources_path, args.output_path, package_name)
-    else:
-        git_hash = build_utils.get_githash(args.rocm_jax_git_hash)
-        build_utils.build_wheel(
-            sources_path,
-            args.output_path,
-            package_name,
-            git_hash=git_hash,
-        )
-finally:
-    if tmpdir:
-        tmpdir.cleanup()
+        if args.enable_rocm:
+            prepare_rocm_plugin_wheel(
+                pathlib.Path(sources_path),
+                cpu=args.cpu,
+                rocm_version=args.platform_version,
+            )
+            package_name = "jax rocm plugin"
+        else:
+            raise ValueError("Unsupported backend. Choose 'rocm'.")
+
+        if args.editable:
+            build_utils.build_editable(sources_path, args.output_path, package_name)
+        else:
+            git_hash = build_utils.get_githash(args.rocm_jax_git_hash)
+            build_utils.build_wheel(
+                sources_path,
+                args.output_path,
+                package_name,
+                git_hash=git_hash,
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* Adding rpath for /opt/rocm/libs since librccl.so etc is not found

* fix linting

* remove --force-rpath to enable user to set LD_LIBRARY_PATH

* black linting fixes

* edit pylint config to disable duplicate-code warning, will refactor the whole repo in the future.

(cherry picked from commit 4c6190ff2e0be8b8288ff57e219b237f0055525a)

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
