### PR TITLE
Use wheels from latest scheduled nightly run in Llama perf

### DIFF
--- a/.github/workflows/llama-perf.yml
+++ b/.github/workflows/llama-perf.yml
@@ -164,11 +164,10 @@ jobs:
                 -R ROCm/rocm-jax \
                 -w nightly.yml \
                 -L 200 \
-                --json databaseId,event,conclusion,createdAt \
+                --json databaseId,event,createdAt \
                 -q '
                   map(select(
-                    .event == "schedule" and
-                    .conclusion == "success"))
+                    .event == "schedule"))
                   | max_by(.createdAt)
                   | .databaseId') \
               -R ROCm/rocm-jax \


### PR DESCRIPTION
This PR updates Llama performance workflow to pull wheels from the latest scheduled nightly run. It always prefers scheduled builds instead of manually triggered runs. 