### PR TITLE
Updated XLA pinned to tip of rocm/xla, branch rocm-jaxlib-v0.7.1

### DIFF
--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -16,8 +16,8 @@ load("//third_party:repo.bzl", "amd_http_archive")
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update XLA_SHA256 with the result.
 
-XLA_COMMIT = "2e5971172f0c0d8f3a4c37b55cc1b53b4ec37cae"
-XLA_SHA256 = "4c31305acad30da49740ab78670ba2699ba45f4a01c4fdc9a5e32e60f9933509"
+XLA_COMMIT = "4178517b7d7e5e3318ea4b701b01dc06847b73b0"
+XLA_SHA256 = "b5880b649c0037e2c38162d300de3ef44d6620b9e0e877d0366899493dd6a935"
 
 def repo():
     amd_http_archive(


### PR DESCRIPTION
## Motivation

Bumping up XLA commit to tip of branch rocm-jaxlib-v0.7.1 on rocm/xla. It is related to missing rounding mode when converting floating point types. Requires a change in Triton code (fix is already present on openai Triton).

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Jax Unit tests

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
All Passed

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
