### PR TITLE
Run CI on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-      - 'release/*'
+      - 'rocm-jaxlib-v*'
   pull_request:
     branches:
       - master
-      - 'release/*'
+      - 'rocm-jaxlib-v*'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
When we make a PR into a release branch, CI should get run on it to ensure that it builds properly and passes basic unit tests. I previously thought that we'd name or release branches something like `release/blahblahblah`, but we've continued with the legacy `rocm-jaxlib-vX.X.X` naming from before. This changes the CI filters to use the `rocm-jaxlib-vX.X.X` naming. Important caveat is that PRs only get run on release branches that we port this change to.
