### PR TITLE
Bump dev setup build number for ROCm 7.2.0 for 0.8.0

### DIFF
--- a/tools/docker_dev_setup.sh
+++ b/tools/docker_dev_setup.sh
@@ -29,7 +29,7 @@ dpkg-reconfigure --frontend noninteractive tzdata
 
 # Default values
 rocm_version="7.2.0"
-rocm_build_number="16623"
+rocm_build_number="16864"
 rocm_job_name="compute-rocm-dkms-no-npi-hipclang"
 
 # Parse named command-line arguments


### PR DESCRIPTION
Missed when moving to 0.8.0, this bumps up the build number for the dev setup to an internal build of ROCm 7.2.0.

Cherry-pick from: https://github.com/ROCm/rocm-jax/pull/185