### PR TITLE
Add RBE secrets to nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,5 +101,5 @@ jobs:
 
           python3 build/ci_build test \
             "ghcr.io/rocm/jax-ubu22.rocm${ROCM_VERSION//.}:${GITHUB_SHA}" \
-            --test-cmd "bash ci/jax_rbe/pr_setup.sh && ci/jax_rbe/pr_test.sh 0.7.1 3.12"
+            --test-cmd "bash ci/jax_rbe/pr_setup.sh && ci/jax_rbe/pr_test.sh 0.8.0 3.12"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,6 +33,9 @@ jobs:
       rocm-build-job: ${{ matrix.rocm-build-job }}
       rocm-build-num: ${{ matrix.rocm-build-num }}
       runner-label: ${{ matrix.runner-label }}
+    secrets:
+      rbe_ci_cert: ${{ secrets.RBE_CI_CERT }}
+      rbe_ci_key: ${{ secrets.RBE_CI_KEY }}
   call-build-docker:
     needs: call-build-wheels
     strategy:

--- a/ci/jax_rbe/pr_test.sh
+++ b/ci/jax_rbe/pr_test.sh
@@ -44,8 +44,9 @@ python3 build/build.py build --wheels=jax-rocm-plugin --configure_only --python_
     --test_output=errors \
     //tests:core_test_gpu \
     //tests:linalg_test_gpu \
+    //tests:ffi_test_gpu \
     --test_filter=CoreTest \
     --test_filter=JaxprTypeChecks \
     --test_filter=DynamicShapesTest \
-    --test_filter=testMatmul
+    --test_filter=ScipyLinalgTest
 

--- a/ci/jax_rbe/pr_test.sh
+++ b/ci/jax_rbe/pr_test.sh
@@ -23,8 +23,8 @@ pushd "${JAX_DIR}" || exit
 if ! grep -q jax_rocm7 build/requirements.in; then
     {
         echo "jaxlib==${JAX_VERSION}"
-        echo "${WHEELHOUSE}/jax_rocm7_pjrt-${JAX_VERSION}-py3-none-manylinux_2_28_x86_64.whl"
-        echo "${WHEELHOUSE}/jax_rocm7_plugin-${JAX_VERSION}-cp${PYTHON//.}-cp${PYTHON//.}-manylinux_2_28_x86_64.whl"
+	echo ${WHEELHOUSE}/jax_rocm7_pjrt*${JAX_VERSION}*
+	echo ${WHEELHOUSE}/jax_rocm7_plugin*${JAX_VERSION}*
     } >> build/requirements.in
 fi
 

--- a/ci/jax_rbe/pr_test.sh
+++ b/ci/jax_rbe/pr_test.sh
@@ -43,10 +43,5 @@ python3 build/build.py build --wheels=jax-rocm-plugin --configure_only --python_
     --test_verbose_timeout_warnings \
     --test_output=errors \
     //tests:core_test_gpu \
-    //tests:linalg_test_gpu \
-    //tests:ffi_test_gpu \
-    --test_filter=CoreTest \
-    --test_filter=JaxprTypeChecks \
-    --test_filter=DynamicShapesTest \
-    --test_filter=ScipyLinalgTest
+    //tests:ffi_test_gpu
 

--- a/ci/jax_rbe/pr_test.sh
+++ b/ci/jax_rbe/pr_test.sh
@@ -24,7 +24,7 @@ if ! grep -q jax_rocm7 build/requirements.in; then
     {
         echo "jaxlib==${JAX_VERSION}"
 	echo ${WHEELHOUSE}/jax_rocm7_pjrt*${JAX_VERSION}*
-	echo ${WHEELHOUSE}/jax_rocm7_plugin*${JAX_VERSION}*
+	echo ${WHEELHOUSE}/jax_rocm7_plugin*${JAX_VERSION}*${PYTHON//.}*
     } >> build/requirements.in
 fi
 


### PR DESCRIPTION
https://github.com/ROCm/rocm-jax/pull/151 enabled RBE for PR builds and changed the build-wheels.yml to require secrets to be passed into the workflow. However, 151 didn't adjust the nightly workflow to pass the required secrets when it calls the wheel build workflow. This change adds those required secrets to the workflow call.
