### PR TITLE
Add ROCm version suffix to jaxlib

### DIFF
--- a/jax_rocm_plugin/build/rocm/ci_build
+++ b/jax_rocm_plugin/build/rocm/ci_build
@@ -58,7 +58,7 @@ def build_jaxlib_wheel(rocm_version, pyver_string):
             "--bazel_options=--repo_env=ML_WHEEL_TYPE=release",
             f"--bazel_options=--repo_env=ML_WHEEL_VERSION_SUFFIX=\"+rocm{rocm_version}\"" \
             "&&",
-            "auditwheel", "repair", "dist/jaxlib*.whl", "-w", "../", "&&",
+            "auditwheel", "repair", "--plat", "manylinux_2_27_x86_64", "--only-plat", "dist/jaxlib*.whl", "-w", "../", "&&",
             ]
 
     cmd += ["popd", "&&",  "rm -rf /wheelhouse/jax_repo",]


### PR DESCRIPTION
## Motivation

TheRock needs wheels with the ROCm version in the version suffix so that they can differentiate between JAX wheels built against different nightly versions of ROCm/TheRock. This has already been done for the plugin wheels, and this change adds the suffix to the `jaxlib` wheel.

## Technical Details

Adds a suffix to the `jaxlib` wheel build using the `ML_WHEEL_VERSION_SUFFIX` environment variable.

## Test

Ran `build/ci_build dist_wheels ...` locally and confirmed that the `jaxlib` wheel that it produces has `+rocmX.Y.Zabc123` in the version suffix.
