### PR TITLE
Port run CI on release branches for 0.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-      - 'release/*'
+      - 'rocm-jaxlib-v*'
   pull_request:
     branches:
       - master
-      - 'release/*'
+      - 'rocm-jaxlib-v*'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Enable CI for PRs on the 0.8.0 branch

Cherry-picked from: https://github.com/ROCm/rocm-jax/pull/182