### PR TITLE
Change jax version used in nightly to 0.8.0.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,7 +75,7 @@ jobs:
           # TODO: Change the repo and ref once we figure out how exactly we're going to
           #       manage tests
           repository: rocm/jax
-          ref: rocm-jaxlib-v0.7.1
+          ref: rocm-jaxlib-v0.8.0
           path: jax
       - name: Authenticate to GitHub Container Registry
         run: |


### PR DESCRIPTION
## Motivation

Nightly workflow is failing with a version mismatch between jax, jaxlib, and the rocm plugin and pjrt.

## Technical Details

This patch moves the reference used for jax to 0.8.0.

## Test Plan

We will run the nightly workflow before merging and ensure it passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
