### PR TITLE
Refactor commit_info.py to use single 'commits' dict

### DIFF
--- a/build/ci_build
+++ b/build/ci_build
@@ -51,15 +51,15 @@ def _get_commit_info_from_wheel():
         )
         commit_content = whl.read(commit_info_file).decode("utf-8")
 
-    # Matches variable assignments with their hexadecimal commit value
-    # xla_commit = "abc123def"
-    pattern = re.compile(r'(\w+)\s*=\s*[\'"]([0-9a-fA-F]+)[\'"]')
+    # Parse the commits dictionary from commit_info.py
+    # Matches: "repo/name": "abc123def"
+    pattern = re.compile(r'[\'"]([^"\']+)[\'"]\s*:\s*[\'"]([0-9a-fA-F]+)[\'"]')
     commits = dict(pattern.findall(commit_content))
 
     return {
-        "xla_commit": commits["xla_commit"],
-        "jax_commit": commits["jax_commit"],
-        "rocm_jax_commit": commits["rocm_jax_commit"],
+        "xla_commit": commits["ROCm/xla"],
+        "jax_commit": commits["jax"],
+        "rocm_jax_commit": commits["ROCm/rocm-jax"],
     }
 
 

--- a/jax_rocm_plugin/jaxlib_ext/tools/build_utils.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_utils.py
@@ -151,10 +151,11 @@ def write_commit_info(plugin_dir, xla_commit, jax_commit, rocm_jax_commit):
         f"""
       # auto-generated; do not edit
 
-      # Commit information
-      xla_commit = "{xla_commit}"
-      jax_commit = "{jax_commit}"
-      rocm_jax_commit = "{rocm_jax_commit}"
+      commits = {{
+          "ROCm/xla": "{xla_commit}",
+          "ROCm/rocm-jax": "{rocm_jax_commit}",
+          "jax": "{jax_commit}",
+      }}
   """
     )
 

--- a/jax_rocm_plugin/pjrt/tools/build_utils.py
+++ b/jax_rocm_plugin/pjrt/tools/build_utils.py
@@ -151,10 +151,11 @@ def write_commit_info(plugin_dir, xla_commit, jax_commit, rocm_jax_commit):
         f"""
       # auto-generated; do not edit
 
-      # Commit information
-      xla_commit = "{xla_commit}"
-      jax_commit = "{jax_commit}"
-      rocm_jax_commit = "{rocm_jax_commit}"
+      commits = {{
+          "ROCm/xla": "{xla_commit}",
+          "ROCm/rocm-jax": "{rocm_jax_commit}",
+          "jax": "{jax_commit}",
+      }}
   """
     )
 


### PR DESCRIPTION
Refactors commit_info.py to use a single commits dictionary instead of separate variables, making it simpler to access. 

Usage - 
from jax_plugins.xla_rocm7.commit_info import commits
print(commits)
