### PR TITLE
Update JAX version used in nightly workflow for the release branch

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,7 +75,7 @@ jobs:
           # TODO: Change the repo and ref once we figure out how exactly we're going to
           #       manage tests
           repository: rocm/jax
-          ref: rocm-jaxlib-v0.7.1
+          ref: rocm-jaxlib-v0.8.0
           path: jax
       - name: Authenticate to GitHub Container Registry
         run: |


### PR DESCRIPTION
This PR updates JAX version used in nightly workflow for the release branch, `rocm-jaxlib-v0.8.0`. We run the nightly workflow directly from this branch as well. This is a cherry-pick of https://github.com/ROCm/rocm-jax/pull/197.

(cherry picked from commit 454326a9d6f62ffc2cd2a28f8e6bd2b011923dcc)