### PR TITLE
Pre-build manylinux builder images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,0 @@
-*
-!build/*
-!wheelhouse/*
-!jax_rocm_plugin/build/rocm/*
-!jax_rocm_plugin/third_party/jax/*

--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -10,6 +10,15 @@ on:
       - 'build/ci_build'
       - '.github/workflows/build-base-docker.yml'
       - 'docker/Dockerfile*'
+      - 'docker/manylinux/*'
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'build/ci_build'
+      - '.github/workflows/build-base-docker.yml'
+      - 'docker/Dockerfile*'
+      - 'docker/manylinux/*'
 
 jobs:
   build-base-images:
@@ -96,3 +105,68 @@ jobs:
             docker tag "${image_tag}" "${ghcr_image_latest}"
             docker push "${ghcr_image_latest}"
           fi
+
+  build-manylinux-builder-images:
+    runs-on: ${{ matrix.runner-label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rocm-version: ["7.1.1", "7.2.0"]
+        include:
+          - rocm-version: "7.1.1"
+            runner-label: "linux-x86-64-1gpu-amd"
+          - rocm-version: "7.2.0"
+            runner-label: "linux-x86-64-1gpu-amd"
+    steps:
+      - name: Clean up old runs
+        run: |
+          ls -lah
+          # Make sure that we own all of the files so that we have permissions to delete them
+          docker run --rm -v "./:/rocm-jax" ubuntu \
+            /bin/bash -c "shopt -s dotglob; chown -R $UID /rocm-jax/* || true"
+          # Remove any old work directories from this machine
+          rm -rf * || true
+          ls -lah
+          # Clean up any docker stuff that's more than a week old
+          docker system prune -a --filter "until=168h"
+          # Stop any containers running for more than 12 hours. No CI job should take this long.
+          docker ps --format="{{.RunningFor}} {{.Names}}" | grep hours \
+            | awk -F: '{if($1>12)print$1}' | awk ' {print $4} ' | xargs docker stop || true
+      - uses: actions/checkout@v4
+      - name: Build docker images
+        run: |
+          python3 build/ci_build \
+            --rocm-version="${{ matrix.rocm-version }}" \
+            --rocm-build-job="${{ matrix.rocm-build-job }}" \
+            --rocm-build-num="${{ matrix.rocm-build-num }}" \
+            build_manylinux_dockers
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push docker images
+        env:
+          ROCM_VERSION: ${{ matrix.rocm-version }}
+          ROCM_BUILD_JOB: >-
+            ${{ matrix.rocm-build-job && format('-{0}', inputs.rocm-build-job) || '' }}
+          ROCM_BUILD_NUM: >-
+            ${{ matrix.rocm-build-num && format('-{0}', inputs.rocm-build-num) || '' }}
+        run: |
+          image_tag="ghcr.io/rocm/jax-manylinux_2_28-rocm-${ROCM_VERSION}${ROCM_BUILD_JOB}${ROCM_BUILD_NUM}"
+
+          # Push with commit SHA tag
+          sha_image_tag="${image_tag}:${GITHUB_SHA}"
+          echo "Image name (SHA): ${sha_image_tag}"
+          docker tag "${image_tag}" "${sha_image_tag}"
+          docker push "${sha_image_tag}"
+
+          # Push with latest tag (only for schedule and workflow_dispatch, not PRs)
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            latest_image_tag="${image_tag}:latest"
+            echo "Image Name (latest): ${latest_image_tag}"
+            docker tag "${image_tag}" "${latest_image_tag}"
+            docker push "${latest_image_tag}"
+          fi
+

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -32,6 +32,10 @@ on:
         required: false
         type: string
         default: 'rocm-jaxlib-v0.8.2'
+      builder-image:
+        required: false
+        type: string
+        default: ''
     secrets:
       rbe_ci_key:
         required: true
@@ -89,6 +93,7 @@ jobs:
             --jax-source-dir="./jax" \
             dist_wheels \
             --rbe
+            --builder-image="${{ inputs.builder-image }}"
       - name: Archive plugin wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     secrets:
       rbe_ci_cert: ${{ secrets.RBE_CI_CERT }}
       rbe_ci_key: ${{ secrets.RBE_CI_KEY }}
+      builder-image: "search"
   call-build-docker:
     needs: call-build-wheels
     strategy:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,6 +37,7 @@ jobs:
     secrets:
       rbe_ci_cert: ${{ secrets.RBE_CI_CERT }}
       rbe_ci_key: ${{ secrets.RBE_CI_KEY }}
+      builder-image: "search"
   call-build-docker:
     needs: call-build-wheels
     strategy:

--- a/build/ci_build
+++ b/build/ci_build
@@ -28,6 +28,9 @@ import json
 import re
 
 
+MANYLINUX_IMAGE_BASE_NAME = "ghcr.io/rocm/jax-manylinux_2_28"
+
+
 def _get_labels(image_name):
     """Return image labels via docker inspect; print warning if image is missing."""
     try:
@@ -110,6 +113,68 @@ def _get_commit_info_from_wheel():
     }
 
 
+def _docker_image_exists(image):
+    """Check if a docker image exists locally or is able to be pulled"""
+    # Use docker inspect to see if the image exists
+    try:
+        subprocess.run(["docker", "inspect", image], check=True)
+    except subprocess.CalledProcessError:
+        # If we can't find the image with inspect, try pulling it
+        print(f"Could not find image '{image}' locally with docker inspect. Attempting to pull it.")
+        try:
+            subprocess.run(["docker", "pull", image], check=True)
+        except subprocess.CalledProcessError:
+            print(f"Could not find image '{image}' locally or pull it.")
+            return False
+    return True
+
+
+def _construct_manylinux_builder_image_name(rocm_version, rocm_build_job="", rocm_build_num="", therock_path=None):
+    """Create an image name that includes the ROCm ersion, build job, build number, etc"""
+    return "{base_name}-{rocm_type}-{rocm_version}{rocm_build_job}{rocm_build_num}".format(
+        base_name=MANYLINUX_IMAGE_BASE_NAME,
+        rocm_type="therock" if therock_path else "rocm",
+        rocm_version=rocm_version,
+        rocm_build_job="-%s" % rocm_build_job if rocm_build_job else "",
+        rocm_build_num="-%s" % rocm_build_num if rocm_build_num else "",
+    )
+
+
+def build_manylinux_dockers(
+    rocm_version, rocm_build_job="", rocm_build_num="", therock_path=None, tag=None
+):
+    """Build a manylinux image that can be used for building release-ready JAX wheels"""
+    if tag:
+        constructed_tag = tag
+    else:
+        constructed_tag = _construct_manylinux_builder_image_name(rocm_version, rocm_build_job, rocm_build_num, therock_path)
+
+    if therock_path:
+        cmd = [
+            "docker",
+            "build",
+            "-t=%s" % constructed_tag,
+            "--file=docker/manylinux/Dockerfile.jax-manylinux_2_28-therock",
+            "--build-arg=ROCM_VERSION=%s" % rocm_version,
+            "--build-arg=THEROCK_PATH=%s" % therock_path,
+            #"--build-context=%s" % therock_path,
+            ".",
+        ]
+    else:
+        cmd = [
+            "docker",
+            "build",
+            "-t=%s" % constructed_tag,
+            "--file=docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm",
+            "--build-arg=ROCM_VERSION=%s" % rocm_version,
+            "--build-arg=ROCM_BUILD_JOB=%s" % rocm_build_job,
+            "--build-arg=ROCM_BUILD_NUM=%s" % rocm_build_num,
+            ".",
+        ]
+    subprocess.run(cmd, check=True)
+    return constructed_tag
+
+
 def dist_wheels(
     rocm_version,
     python_versions,
@@ -120,18 +185,36 @@ def dist_wheels(
     therock_path=None,
     rbe=False,
     compiler="gcc",
+    builder_image=None,
 ):
     jax_plugin_dir = "jax_rocm_plugin"
 
+    # If we weren't passed a builder image in the args, create an image
+    local_builder_image = builder_image
+    if not local_builder_image:
+        print("No manylinux builder image passed. Building a new builder image...")
+        local_builder_image = build_manylinux_dockers(
+            rocm_version=rocm_version,
+            rocm_build_job=rocm_build_job,
+            rocm_build_num=rocm_build_num,
+            therock_path=therock_path,
+        )
+    # If builder-image is set to 'search', try and find one based off of the passed ROCm info
+    elif local_builder_image == "search":
+        print("Searching for manylinux builder image...")
+        local_builder_image = _construct_manylinux_builder_image_name(rocm_version, rocm_build_job, rocm_build_num, therock_path)
+        if not _docker_image_exists(local_builder_image):
+            print(f"ERROR: Builder image '{local_builder_image}' does not exist")
+            exit(1)
+
+    # Build the wheels
     cmd = [
         "python3",
         "build/rocm/ci_build",
         "--rocm-version=%s" % rocm_version,
         "--python-versions=%s" % ",".join(python_versions),
-        "--rocm-build-job=%s" % rocm_build_job,
-        "--rocm-build-num=%s" % rocm_build_num,
-        "--therock-path=%s" % therock_path,
         "--compiler=%s" % compiler,
+        "--builder-image=%s" % local_builder_image,
     ]
 
     if xla_source_dir:
@@ -539,8 +622,19 @@ def parse_args():
 
     subp = p.add_subparsers(dest="action", required=True)
 
+    ml_parser = subp.add_parser("build_manylinux_dockers")
+    ml_parser.add_argument(
+        "--tag", "-t", type=str, help="Override the default image name and tag"
+    )
+
     dwp = subp.add_parser("dist_wheels")
     dwp.add_argument("--rbe", action="store_true", help="Use Bazel RBE for building")
+    dwp.add_argument(
+        "--builder-image",
+        "-b",
+        type=str,
+        help="Name of the docker image to build with",
+    )
 
     dtestp = subp.add_parser("test_docker")
     dtestp.add_argument("--docker-build-only", action="store_true")
@@ -603,8 +697,16 @@ def parse_args():
 def main():
     args = parse_args()
 
-    if args.action == "dist_wheels":
+    if args.action == "build_manylinux_dockers":
+        build_manylinux_dockers(
+            rocm_version=args.rocm_version,
+            rocm_build_job=args.rocm_build_job,
+            rocm_build_num=args.rocm_build_num,
+            therock_path=args.therock_path,
+            tag=args.tag,
+        )
 
+    if args.action == "dist_wheels":
         dist_wheels(
             rocm_version=args.rocm_version,
             python_versions=args.python_versions,
@@ -615,6 +717,7 @@ def main():
             therock_path=args.therock_path,
             rbe=args.rbe,
             compiler=args.compiler,
+            builder_image=args.builder_image,
         )
 
     if args.action == "build_dockers":

--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -88,7 +88,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
     gcloud config set auth/disable_credentials True
 
 # Install ROCm:
-RUN --mount=type=bind,source=jax_rocm_plugin/build/rocm/tools/get_rocm.py,target=get_rocm.py \
+RUN --mount=type=bind,source=tools/get_rocm.py,target=get_rocm.py \
     --mount=type=cache,target=/var/cache/apt \
     --mount=type=bind,from=therock,target=/tmp/therock/ \
     python3 get_rocm.py --rocm-version=$ROCM_VERSION --job-name=$ROCM_BUILD_JOB --build-num=$ROCM_BUILD_NUM --therock-path=$THEROCK_PATH

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
@@ -1,0 +1,30 @@
+FROM quay.io/pypa/manylinux_2_28_x86_64
+
+ARG ROCM_VERSION
+ARG ROCM_BUILD_JOB
+ARG ROCM_BUILD_NUM
+ENV GPU_DEVICE_TARGETS="gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1200 gfx1201"
+
+# Install patchelf and headers for numactl
+RUN --mount=type=cache,target=/var/cache/dnf \
+    dnf install -y patchelf numactl-devel
+
+# Install ROCm
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=bind,source=./tools/get_rocm.py,target=get_rocm.py \
+    python3 get_rocm.py --rocm-version=$ROCM_VERSION --job-name=$ROCM_BUILD_JOB --build-num=$ROCM_BUILD_NUM
+ENV PATH="$PATH:/opt/rocm/bin:/opt/rocm/llvm/bin"
+RUN printf '%s\n' > /opt/rocm/bin/target.lst ${GPU_DEVICE_TARGETS}
+
+# Install LLVM 18 and dependencies.
+RUN --mount=type=cache,target=/var/cache/dnf \
+    dnf install -y wget && dnf clean all
+RUN mkdir /tmp/llvm-project && wget -qO - https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-18.1.8.tar.gz | tar -xz -C /tmp/llvm-project --strip-components 1 && \
+    mkdir /tmp/llvm-project/build && cd /tmp/llvm-project/build && cmake -DLLVM_ENABLE_PROJECTS='clang;lld' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-18/ ../llvm && \
+    make -j$(nproc) && make -j$(nproc) install && rm -rf /tmp/llvm-project
+
+# Copy in our clang configuiration file
+COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang++.cfg
+COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang.cfg
+COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang++.cfg
+COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang.cfg

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -1,0 +1,31 @@
+FROM quay.io/pypa/manylinux_2_28_x86_64
+
+
+ARG ROCM_VERSION
+ARG THEROCK_PATH
+ENV GPU_DEVICE_TARGETS="gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1200 gfx1201"
+
+# Install patchelf and headers for numactl
+RUN --mount=type=cache,target=/var/cache/dnf \
+    dnf install -y patchelf numactl-devel
+
+# Install ROCm
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=bind,source=./tools/get_rocm.py,target=get_rocm.py \
+    python3 get_rocm.py --rocm-version=$ROCM_VERSION --therock-path=$THEROCK_PATH
+ENV PATH="$PATH:/opt/rocm/bin:/opt/rocm/llvm/bin"
+RUN printf '%s\n' > /opt/rocm/bin/target.lst ${GPU_DEVICE_TARGETS}
+
+# Install LLVM 18 and dependencies.
+RUN --mount=type=cache,target=/var/cache/dnf \
+    dnf install -y wget && dnf clean all
+RUN mkdir /tmp/llvm-project && wget -qO - https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-18.1.8.tar.gz | tar -xz -C /tmp/llvm-project --strip-components 1 && \
+    mkdir /tmp/llvm-project/build && cd /tmp/llvm-project/build && cmake -DLLVM_ENABLE_PROJECTS='clang;lld' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-18/ ../llvm && \
+    make -j$(nproc) && make -j$(nproc) install && rm -rf /tmp/llvm-project
+
+# Copy in our clang configuiration file
+COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang++.cfg
+COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang.cfg
+COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang++.cfg
+COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang.cfg
+

--- a/docker/manylinux/clang.cfg
+++ b/docker/manylinux/clang.cfg
@@ -1,0 +1,2 @@
+# tell clang where it can find gcc so that it can use gcc's standard libraries
+--gcc-toolchain=/opt/rh/gcc-toolset-14/root/usr

--- a/jax_rocm_plugin/build/rocm/ci_build
+++ b/jax_rocm_plugin/build/rocm/ci_build
@@ -26,13 +26,6 @@ import subprocess
 import sys
 
 
-def image_by_name(name):
-    cmd = ["docker", "images", "-q", "-f", "reference=%s" % name]
-    out = subprocess.check_output(cmd)
-    image_id = out.decode("utf8").strip().split("\n")[0] or None
-    return image_id
-
-
 def dist_wheels(
     rocm_version,
     python_versions,
@@ -43,50 +36,14 @@ def dist_wheels(
     therock_path,
     rbe,
     compiler,
+    builder_image,
 ):
     if xla_path:
         xla_path = os.path.abspath(xla_path)
 
-    # create manylinux image with requested ROCm installed
-    image = "jax-manylinux_2_28_x86_64_rocm%s" % rocm_version.replace(".", "")
-
-    # Try removing the Docker image.
-    try:
-        subprocess.run(["docker", "rmi", image], check=True)
-        print(f"Image {image} removed successfully.")
-    except subprocess.CalledProcessError as e:
-        print(f"Failed to remove Docker image {image}: {e}")
-
-    cmd = [
-        "docker",
-        "build",
-        "-f",
-        "build/rocm/build_wheels/Dockerfile.manylinux_2_28_x86_64.rocm",
-        "--build-arg=ROCM_VERSION=%s" % rocm_version,
-        "--build-arg=ROCM_BUILD_JOB=%s" % rocm_build_job,
-        "--build-arg=ROCM_BUILD_NUM=%s" % rocm_build_num,
-        "--tag=%s" % image,
-    ]
-
-    if os.path.isdir(therock_path):
-        cmd.append("--build-arg=THEROCK_PATH=/tmp/therock/")
-        cmd.append("--build-context=therock=%s" % therock_path)
-    else:
-        if therock_path:
-            cmd.append("--build-arg=THEROCK_PATH=%s" % therock_path)
-        os.makedirs("tmp_therock", exist_ok=True)
-        cmd.append("--build-context=therock=tmp_therock")
-
-    cmd.append(".")
-
-    if not image_by_name(image):
-        _ = subprocess.run(cmd, check=True)
-
-    # use image to build JAX/jaxlib wheels
+    # Use the manylinux image to build JAX/jaxlib wheels
     os.makedirs("wheelhouse", exist_ok=True)
-
     pyver_string = ",".join(python_versions)
-
     container_xla_path = "/xla"
     container_jax_path = "/jax"
     container_plugin_path = "/jax_rocm_plugin"
@@ -113,11 +70,10 @@ def dist_wheels(
         bw_cmd.append("--rbe")
 
     bw_cmd.append(container_plugin_path)
-
+    bw_cmd.append("/jax")
     container_cmd = " ".join(bw_cmd)
 
     cmd = ["docker", "run"]
-
     mounts = [
         "-v",
         os.path.abspath("../") + ":/repo",
@@ -151,7 +107,7 @@ def dist_wheels(
             "GIT_WORK_TREE=/repo",
             "-e",
             "ROCM_VERSION_EXTRA=" + rocm_version,
-            image,
+            builder_image,
             "bash",
             "-c",
             container_cmd,
@@ -224,24 +180,6 @@ def parse_args():
     )
 
     p.add_argument(
-        "--rocm-build-job",
-        default="",
-        help="ROCm build job for development ROCm builds",
-    )
-
-    p.add_argument(
-        "--rocm-build-num",
-        default="",
-        help="ROCm build number for development ROCm builds",
-    )
-
-    p.add_argument(
-        "--therock-path",
-        default=None,
-        help="Either a URL that points to a tarball containing TheRock or a path to a local directory containing TheRock",
-    )
-
-    p.add_argument(
         "--xla-source-dir",
         help="Path to XLA source to use during plugin and jaxlib build, instead of builtin XLA",
     )
@@ -261,6 +199,11 @@ def parse_args():
         "--compiler",
         choices=["gcc", "clang"],
         help="Compiler backend to use when compiling jax/jaxlib",
+    )
+
+    p.add_argument(
+        "--builder-image",
+        default=None,
     )
 
     subp = p.add_subparsers(dest="action", required=True)
@@ -287,6 +230,7 @@ def main():
             args.therock_path,
             args.rbe,
             args.compiler,
+            args.builder_image,
         )
 
     elif args.action == "test":

--- a/stack.py
+++ b/stack.py
@@ -350,8 +350,6 @@ def dev_docker(rm):
     cur_abs_path = os.path.abspath(os.curdir)
     image_name = "ubuntu:24.04"
 
-    ep = "/rocm-jax/tools/docker_dev_setup.sh"
-
     cmd = [
         "docker",
         "run",
@@ -368,11 +366,7 @@ def dev_docker(rm):
         "seccomp=unconfined",
         "-v",
         "%s:/rocm-jax" % cur_abs_path,
-        "--env",
-        "ROCM_JAX_DIR=/rocm-jax",
-        "--env",
-        "_IS_ENTRYPOINT=1",
-        "--entrypoint=%s" % ep,
+        "--env=ROCM_JAX_DIR=/rocm-jax",
     ]
 
     if rm:

--- a/tools/get_rocm.py
+++ b/tools/get_rocm.py
@@ -233,11 +233,14 @@ def _install_therock(rocm_version, therock_path):
     os.symlink(rocm_real_path, rocm_sym_path, target_is_directory=True)
 
     # Make a symlink to amdgcn to fix LLVM not being able to find binaries
-    os.symlink(
-        rocm_real_path + "/lib/llvm/amdgcn/",
-        rocm_real_path + "/amdgcn",
-        target_is_directory=True,
-    )
+    try:
+        os.symlink(
+            rocm_real_path + "/lib/llvm/amdgcn/",
+            rocm_real_path + "/amdgcn",
+            target_is_directory=True,
+        )
+    except FileExistsError:
+        LOG.info("%s already exists", rocm_sym_path)
 
 
 def _setup_internal_repo(system, rocm_version, job_name, build_num):
@@ -431,10 +434,8 @@ minrate=1
     with open("/etc/yum.repos.d/amdgpu.repo", "w") as afd:
         if rocm_version_str.startswith("7"):
             repodir = "graphics"
-            rhel_minor = 10
         else:
             repodir = "amdgpu"
-            rhel_minor = 8
         afd.write("""
 [amdgpu]
 name=amdgpu


### PR DESCRIPTION
## Motivation

Currently, our build system creates a manylinux Docker image with ROCm and Clang installed as part `build/ci_build dist_wheels`. This is the usual CI command for building wheels. However, it is quite slow to rebuild the Docker image every time we want to build the wheels. The Docker build cache is also unreliable given that we're increasingly using ephemeral Kubernetes runners in CI. Instead, we can build the manylinux image weekly and just pull the image when we need it.

## Technical Details

This change adds the `build/ci_build build_manylinux_dockers` command that will create a manylinux docker image that can be used in `build/ci_build dist_wheels`. The `dist_wheels` command will also search for manylinux images and attempt to pull one from GHCR if one isn't found locally before resorting to building the manylinux image locally. We also add a job to the `build-base-dockers.yml` workflow to build the manylinux images every week and for PRs that modify the manylinux Dockerfiles.

## Test Plan

- [x] Run the `build/ci_build ... build_manylinux_dockers` command locally
- [x] Run the `build-base-dockers.yml` workflow
- [ ] Run the nightly workflow with a new manylinux builder image
