### PR TITLE
Use ROCm RC14 on 0.8.0

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,8 +23,8 @@ jobs:
           - rocm-version: "7.1.0"
             runner-label: "mi-250"
           - rocm-version: "7.2.0"
-            rocm-build-job: "compute-rocm-dkms-no-npi-hipclang"
-            rocm-build-num: "16849"
+            rocm-build-job: "compute-rocm-rel-7.2"
+            rocm-build-num: "14"
             runner-label: "internal"
     uses: ./.github/workflows/build-wheels.yml
     with:
@@ -43,8 +43,8 @@ jobs:
           - rocm-version: "7.1.0"
             runner-label: "mi-250"
           - rocm-version: "7.2.0"
-            rocm-build-job: "compute-rocm-dkms-no-npi-hipclang"
-            rocm-build-num: "16849"
+            rocm-build-job: "compute-rocm-rel-7.2"
+            rocm-build-num: "14"
             runner-label: "internal"
     uses: ./.github/workflows/build-docker.yml
     with:


### PR DESCRIPTION
Move to using the newest release build of ROCm 7.2.0 for the nightly workflow