### PR TITLE
Update JAX & XLA commits in bazel files

### DIFF
--- a/jax_rocm_plugin/third_party/jax/workspace.bzl
+++ b/jax_rocm_plugin/third_party/jax/workspace.bzl
@@ -1,8 +1,8 @@
 
 load("//third_party:repo.bzl", "amd_http_archive")
 
-COMMIT = "5712de44e97c455faed1fd45532e821ca66d025a"
-SHA = "f8fb9e6a7baa789008eb814d138a91340206cbdcebe39c919c0516c8a62a4c65"
+COMMIT = "00e65c328ec9a82428a9f37e38c8583ec606038d"
+SHA = "e95ff2282014bb6b3246fcd633340a5a20d72c2c974e8e10b81277462a1d1bcf"
 
 def repo():
     amd_http_archive(

--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -16,8 +16,8 @@ load("//third_party:repo.bzl", "amd_http_archive")
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update XLA_SHA256 with the result.
 
-XLA_COMMIT = "4178517b7d7e5e3318ea4b701b01dc06847b73b0"
-XLA_SHA256 = "b5880b649c0037e2c38162d300de3ef44d6620b9e0e877d0366899493dd6a935"
+XLA_COMMIT = "487acd877135e9d27969eaff4e21ed2e42ca7223"
+XLA_SHA256 = "3886b82188b08f567c4ad500ca48e7e0f79fb473b57d85c8c900c039b0da28f5"
 
 def repo():
     amd_http_archive(


### PR DESCRIPTION
## Motivation

Latest XLA commit from https://github.com/ROCm/xla/commits/rocm-jaxlib-v0.7.1 is `487acd877135e9d27969eaff4e21ed2e42ca7223`
Latest JAX commits from https://github.com/ROCm/jax/commits/rocm-jaxlib-v0.7.1 is `00e65c328ec9a82428a9f37e38c8583ec606038d`


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
