### PR TITLE
Add docs on bulid.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ More complete build instructions can be [found here](BUILDING.md).
 
 ## Quickbuild
 
+This build must be run on bare metal (not inside a Docker container), and will
+produce a wheels and an Ubuntu24 image with ROCm JAX installed on it.
+
 ```shell
 PYTHON_VERSION=3.12
 ROCM_VERSION=7.2.0


### PR DESCRIPTION
Update the docs to describe how to use the `build.py` without using the devsetup and `stack.py`

TODO: Draft PR. Don't merge yet. Need to add instructions on options for overriding the rocm/jax and rocm/xla version and test out commands with those combinations to make sure they just work.