### PR TITLE
Disable RBE sharding for tests

### DIFF
--- a/jax_rocm_plugin/rbe.bazelrc
+++ b/jax_rocm_plugin/rbe.bazelrc
@@ -21,6 +21,7 @@ test:rocm_rbe --extra_execution_platforms="//platform/linux:ubuntu_gpu"
 test:rocm_rbe --platforms="//platform/linux:ubuntu_gpu"
 test:rocm_rbe --remote_timeout=3600
 test:rocm_rbe --jobs=200
+test:rocm_rbe --test_sharding_strategy=disabled
 test:rocm_rbe --strategy=TestRunner=remote,local
 test:rocm_rbe --worker_sandboxing=true
 test:rocm_rbe --repo_env=REMOTE_GPU_TESTING=1


### PR DESCRIPTION
Test sharding will split up individual tests into several pieces that each get executed on a different RBE worker. This is great when you have a high ratio of workers to tests. Currently, we only have a few dozen GPUs in the RBE cluster, and only as many workers as GPUs. This is shard between JAX and XLA. JAX runs 3 tests as part of each PR, so no need to shard the tests. It will just cause unnecessary load on the network shoveling inputs and outputs back and forth.