### PR TITLE
Bump XLA commit for fusion emitter and silu fixes

### DIFF
--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -16,8 +16,8 @@ load("//third_party:repo.bzl", "amd_http_archive")
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update XLA_SHA256 with the result.
 
-XLA_COMMIT = "d790f9abc77b217e730588f66345f606654ad971"
-XLA_SHA256 = "5cc695bad1fdcf1f10ffe83e64011c979cc30841d780d8015fb647eb89fb8124"
+XLA_COMMIT = "5a486a60b7539479b3ecf089300a4c76f9567680"
+XLA_SHA256 = "a30c4b9017208dc81bffa00751c01c9284f92b630927b46d9b0a93e452b69faf"
 
 def repo():
     amd_http_archive(


### PR DESCRIPTION
Bump the XLA commit to pick up,
* Fusion Emitter device tests https://github.com/ROCm/xla/pull/482
* silu change https://github.com/ROCm/xla/pull/488
* cudnn fixes https://github.com/ROCm/xla/commit/135cbd40b16a10f32a069bba29aa02e88b64ede5