### PR TITLE
move hipInit() after rocprofiler_configure() rocm jaxlib v0.7.1

### DIFF
--- a/jax_rocm_plugin/pjrt/python/__init__.py
+++ b/jax_rocm_plugin/pjrt/python/__init__.py
@@ -139,16 +139,17 @@ def initialize():
     if rocm_plugin_extension is None:
         logger.warning("rocm_plugin_extension not found")
         return
-
-    device_count = rocm_plugin_extension.get_device_count()
-    if device_count <= 0:
-        raise ValueError("No GPUs found")
-
+    
     options = xla_client.generate_pjrt_gpu_plugin_options()
     options["platform_name"] = "ROCM"
     c_api = xb.register_plugin(
         "rocm", priority=500, library_path=str(path), options=options
     )
+    
+    device_count = rocm_plugin_extension.get_device_count()
+    if device_count <= 0:
+        raise ValueError("No GPUs found")
+    
     if rocm_plugin_extension:
         xla_client.register_custom_call_handler(
             "ROCM",


### PR DESCRIPTION
## Motivation

- to address no GPU events with rocm-jax/jax_rocm_plugin/build.py for jax/xla 0.7.1 is https://github.com/ROCm/rocm-jax/blob/master/jax_rocm_plugin/pjrt/python/__init__.py#L143 that triggers hipInit() before loading pjrt plugin, in which rocprofiler_force_configure (rocprofiler_configure()) is called to link rocprofiler-sdk/rocprofiler-register to set up hip intercept api table. https://github.com/ROCm/jax/blob/main/jax/_src/xla_bridge.py#L490, 
- move them after loading pjrt plugin

### Test 
- `root@smc300x-clt-r4c6-18:/work/jax/tests# python3 profiler_test.py`
```
[       OK ] ProfilerTest.testProgrammaticGpuCuptiTracing
[ RUN      ] ProfilerTest.testProgrammaticGpuCuptiTracingWithOptions
[       OK ] ProfilerTest.testProgrammaticGpuCuptiTracingWithOptions
[ RUN      ] ProfilerTest.testProgrammaticProfiling
[       OK ] ProfilerTest.testProgrammaticProfiling
[ RUN      ] ProfilerTest.testProgrammaticProfilingContextManager
[       OK ] ProfilerTest.testProgrammaticProfilingContextManager
[ RUN      ] ProfilerTest.testProgrammaticProfilingContextManagerPathlib
[       OK ] ProfilerTest.testProgrammaticProfilingContextManagerPathlib
[ RUN      ] ProfilerTest.testProgrammaticProfilingErrors
[       OK ] ProfilerTest.testProgrammaticProfilingErrors
[ RUN      ] ProfilerTest.testProgrammaticProfilingPathlib
[       OK ] ProfilerTest.testProgrammaticProfilingPathlib
[ RUN      ] ProfilerTest.testProgrammaticProfilingWithOptions
[       OK ] ProfilerTest.testProgrammaticProfilingWithOptions
[ RUN      ] ProfilerTest.testProgrammaticProfilingWithOptionsPathlib
[       OK ] ProfilerTest.testProgrammaticProfilingWithOptionsPathlib
[ RUN      ] ProfilerTest.testSingleWorkerSamplingMode
[  SKIPPED ] ProfilerTest.testSingleWorkerSamplingMode - Test causes OOMs
[ RUN      ] ProfilerTest.testStartStopServer
[       OK ] ProfilerTest.testStartStopServer
[ RUN      ] ProfilerTest.testTraceAnnotation
[       OK ] ProfilerTest.testTraceAnnotation
[ RUN      ] ProfilerTest.testTraceFunction
[       OK ] ProfilerTest.testTraceFunction
[ RUN      ] ProfilerTest.test_remote_profiler
[  SKIPPED ] ProfilerTest.test_remote_profiler - Test requires xprof and portpicker
----------------------------------------------------------------------
Ran 18 tests in 53.236s
```