### PR TITLE
Revert "Improve check for AMD GPU availability; drop the patchfile (#226)"

### DIFF
--- a/jax_rocm_plugin/pjrt/python/__init__.py
+++ b/jax_rocm_plugin/pjrt/python/__init__.py
@@ -18,9 +18,7 @@ import functools
 import importlib
 import logging
 import os
-import os.path
 import pathlib
-import re
 
 from jax._src.lib import xla_client  # pylint: disable=import-error
 import jax._src.xla_bridge as xb  # pylint: disable=import-error
@@ -33,7 +31,7 @@ for pkg_name in ["jax_rocm7_plugin", "jax_rocm60_plugin", "jaxlib.rocm"]:
             f"{pkg_name}.rocm_plugin_extension"
         )
     except ImportError:
-        rocm_plugin_extension = None  # pylint: disable=invalid-name
+        rocm_plugin_extension = None
     else:
         break
 
@@ -130,58 +128,6 @@ def set_rocm_paths(path):  # pylint: disable=too-many-branches
     os.environ["JAX_ROCM_PLUGIN_INTERNAL_LLD_PATH"] = lld_path
 
 
-def is_amd_gpu_available() -> bool:
-    """Checks if any AMD GPU is available to safeguard loading of the ROCm pjrt.
-
-    Different approaches to this are possible. We chose testing for existence
-    of KFD kernel driver entities as a proxy for the presence of AMD GPUs as
-    a good compromise between performance, reliability and simplicity.
-    Presence of such entities doesn't guarantee that the GPUs are usable through
-    HIP and PJRT, however, we can't do much much better without spawning an
-    additional process with a potentially complicated setup to run actual HIP
-    code. And we don't want to initialize HIP right now inside the current
-    process, because doing so might spoil a proper initialization of the
-    rocprofiler-sdk later during PJRT startup."""
-
-    try:
-        kfd_nodes_path = "/sys/class/kfd/kfd/topology/nodes/"
-        if not os.path.exists(kfd_nodes_path):
-            return False
-
-        # the RE matches strings like "simd_count ##" and extracts the number ##
-        r_simd_count = re.compile(r"\bsimd_count\s+(\d+)\b", re.MULTILINE)
-        # we're using a non-zero simd_count as a trait of a GPU following the
-        # KFD implementation
-        # https://github.com/torvalds/linux/blob/ea1013c1539270e372fc99854bc6e4d94eaeff66/drivers/gpu/drm/amd/amdkfd/kfd_topology.c#L941
-
-        for node in os.listdir(kfd_nodes_path):
-            node_props_path = os.path.join(kfd_nodes_path, node, "properties")
-            if not os.path.exists(node_props_path):
-                continue
-
-            try:
-                file_size = os.path.getsize(node_props_path)
-                # 16KB is more than a reasonable limit
-                if file_size <= 0 or file_size > 16 * 1024:
-                    continue
-
-                with open(node_props_path, "r", encoding="ascii") as f:
-                    match = r_simd_count.search(f.read())
-                    if match:
-                        simd_count = int(match.group(1))
-                        if simd_count > 0:
-                            return True  # one is enough
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                logger.debug(
-                    "Failed to read KFD node file '%s': %s", node_props_path, e
-                )
-                continue
-
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        logger.warning("Failed to check for AMD KFD presence: %s", e)
-    return False
-
-
 def initialize():
     """Initialize the JAX ROCm plugin."""
     path = _get_library_path()
@@ -194,8 +140,9 @@ def initialize():
         logger.warning("rocm_plugin_extension not found")
         return
 
-    if not is_amd_gpu_available():
-        raise ValueError("No AMD GPUs were found, skipping ROCm plugin initialization")
+    device_count = rocm_plugin_extension.get_device_count()
+    if device_count <= 0:
+        raise ValueError("No GPUs found")
 
     options = xla_client.generate_pjrt_gpu_plugin_options()
     options["platform_name"] = "ROCM"

--- a/jax_rocm_plugin/third_party/jax/0004-No-GPU-fail.patch
+++ b/jax_rocm_plugin/third_party/jax/0004-No-GPU-fail.patch
@@ -1,0 +1,58 @@
+From 5c29011923e5845caa7bf68a7ce0f520c2eea7e8 Mon Sep 17 00:00:00 2001
+From: Charles Hofer <Charles.Hofer@amd.com>
+Date: Thu, 13 Nov 2025 21:50:02 +0000
+Subject: [PATCH] No GPU fail
+
+---
+ jaxlib/rocm/BUILD                    | 1 +
+ jaxlib/rocm/rocm_plugin_extension.cc | 9 +++++++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/jaxlib/rocm/BUILD b/jaxlib/rocm/BUILD
+index f59ac817a..806d47efc 100644
+--- a/jaxlib/rocm/BUILD
++++ b/jaxlib/rocm/BUILD
+@@ -528,6 +528,7 @@ nanobind_extension(
+     srcs = ["rocm_plugin_extension.cc"],
+     module_name = "rocm_plugin_extension",
+     deps = [
++	":hip_gpu_kernel_helpers",
+         ":py_client_gpu",
+         "//jaxlib:kernel_nanobind_helpers",
+         "//jaxlib/gpu:gpu_plugin_extension",
+diff --git a/jaxlib/rocm/rocm_plugin_extension.cc b/jaxlib/rocm/rocm_plugin_extension.cc
+index 508aa0b51..082533883 100644
+--- a/jaxlib/rocm/rocm_plugin_extension.cc
++++ b/jaxlib/rocm/rocm_plugin_extension.cc
+@@ -23,6 +23,7 @@ limitations under the License.
+ #include "jaxlib/gpu/gpu_plugin_extension.h"
+ #include "jaxlib/gpu/py_client_gpu.h"
+ #include "jaxlib/kernel_nanobind_helpers.h"
++#include "jaxlib/gpu/gpu_kernel_helpers.h"
+ 
+ namespace nb = nanobind;
+ 
+@@ -82,6 +83,13 @@ nb::dict FfiRegistrations() {
+   return dict;
+ }
+ 
++int ROCmDeviceCount() {
++  int device_count = -1;
++  JAX_THROW_IF_ERROR(JAX_AS_STATUS(hipInit(0)));
++  JAX_THROW_IF_ERROR(JAX_AS_STATUS(hipGetDeviceCount(&device_count)));
++  return device_count;
++}
++
+ }  // namespace
+ 
+ NB_MODULE(rocm_plugin_extension, m) {
+@@ -107,5 +115,6 @@ NB_MODULE(rocm_plugin_extension, m) {
+         return device_ordinal;
+       },
+       nb::arg("data_value"));
++  m.def("get_device_count", &ROCmDeviceCount);
+ }
+ }  // namespace jax
+-- 
+2.34.1
+

--- a/jax_rocm_plugin/third_party/jax/workspace.bzl
+++ b/jax_rocm_plugin/third_party/jax/workspace.bzl
@@ -14,6 +14,7 @@ def repo():
 	    "//third_party/jax:0001-Remove-nvidia_wheel_versions.patch",
 	    "//third_party/jax:0002-Make-jaxlib-targets-visible.patch",
 	    "//third_party/jax:0003-hipblas-typedef-fix.patch",
+	    "//third_party/jax:0004-No-GPU-fail.patch",
 	    "//third_party/jax:0005-Fix-HIP-availability-errors.patch",
         ],
     )


### PR DESCRIPTION
This reverts commit 012d3251a48f24c9c91a640e4872203e8416fe5a as it breaks custom Llama model.