### PR TITLE
To build and install jax, jaxlib, pjrt and plugin at once

### DIFF
--- a/stack.py
+++ b/stack.py
@@ -50,12 +50,13 @@ KERNELS_JAX_OVERRIDE_OPTION="%(kernels_jax_override)s"
 ###
 
 
-.PHONY: test clean install dist
+.PHONY: test clean install dist all_wheels
 
 .default: dist
 
 
 dist: jax_rocm_plugin jax_rocm_pjrt
+all_wheels: clean dist jaxlib_clean jaxlib jaxlib_install install
 
 
 jax_rocm_plugin:


### PR DESCRIPTION
## Motivation

0.8.0: https://github.com/ROCm/rocm-jax/pull/243

Now we can just use one line to build everything (jax, jaxlib, pjrt and plugin) as we're used to.

```
python3 stack.py build --xla-dir=/my/own/xla/path --jax-dir=/my/own/jax/path
```




