### PR TITLE
[WIP] Stack direct build without Makefile

### DIFF
--- a/stack.py
+++ b/stack.py
@@ -493,9 +493,7 @@ def build_and_install(
 
     this_repo_root, xla_path, jax_path = _resolve_relative_paths(xla_dir, jax_dir)
     amdgpu_targets = get_amdgpu_targets()
-
-    # Use "system" to force build to use the container's python version
-    python_version = "system"
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
 
     if not clang_path:
         clang_path = find_clang() or "/usr/lib/llvm-18/bin/clang"

--- a/stack.py
+++ b/stack.py
@@ -3,7 +3,9 @@
 
 import argparse
 import os
+import re
 import subprocess
+import sys
 
 
 TEST_JAX_REPO_REF = "rocm-jaxlib-v0.8.0"

--- a/stack.py
+++ b/stack.py
@@ -189,8 +189,8 @@ def get_amdgpu_targets():
         pass
     # Default targets if rocminfo fails
     targets = (
-        "gfx906,gfx908,gfx90a,gfx942,gfx950,gfx1030,"
-        + "gfx1100,gfx1101,gfx1200,gfx1201"
+        "gfx906,gfx908,gfx90a,gfx942,gfx950,gfx1030," +
+        "gfx1100,gfx1101,gfx1200,gfx1201"
     )
     return targets
 
@@ -493,7 +493,9 @@ def build_and_install(
 
     this_repo_root, xla_path, jax_path = _resolve_relative_paths(xla_dir, jax_dir)
     amdgpu_targets = get_amdgpu_targets()
-    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+    # Use "system" to force build to use the container's python version
+    python_version = "system"
 
     if not clang_path:
         clang_path = find_clang() or "/usr/lib/llvm-18/bin/clang"


### PR DESCRIPTION
This is a more aggressive change based on https://github.com/ROCm/rocm-jax/pull/243 

The build is simple by one line without `Makefile`

```
python3 stack.py build --xla-dir=/your/xla --jax-dir=/your/jax
```

1. Direct Build Implementation: Refactored `stack.py` to handle the entire build and installation process (JAX, jaxlib, PJRT, and plugin) directly using Python subprocesses, removing the dependency on a `Makefile`.

2. Simplified Command Line:
   - Renamed `--kernel-jax-dir` to `--jax-dir`.
   - Enabled the use of the = syntax (e.g., `--xla-dir=/path/to/xla`).
   - Made `--rebuild-makefile` implicit for the build action.


3. New flag `--debug`: You can now add `--debug` to your build or develop commands.
 - Debug configurations: When `--debug` is used, the build process will:
     - Enable `--config=debug` and `--compilation_mode=dbg`
     - Disable stripping of symbols (`--strip=never`).
     - Set maximum debug info level (`-g3`).
     - Disable optimizations (`-O0`) for both C and C++ code.
  - Makefile support: Running `python3 stack.py develop --debug` will generate a `Makefile` configured to use the `CFG_DEBUG` options by default.
  - Example usage:
      - To build everything in debug mode:
```
python3 stack.py build --xla-dir=/your/xla --jax-dir=/your/jax --debug
```
To just generate a Makefile with debug settings:
```
python3 stack.py develop --xla-dir=/your/xla --jax-dir=/your/jax --debug
```

If you really want `Makefile` you can still go with 

```
python3 stack.py develop --xla-dir=/your/xla --jax-dir=/your/jax
```

4. Specific clang path and choose clang18 as default one

```
python3 stack.py build --xla-dir=/your/xla --jax-dir=/your/jax --clang-path=/usr/lib/llvm-18/bin/clang
```