### PR TITLE
Test new runners for CI

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -15,7 +15,7 @@ on:
       runner-label:
         required: false
         type: string
-        default: "mi-250"
+        default: '["mi-250"]'
       artifact-prefix:
         required: false
         default: 'plugin_wheels'
@@ -26,7 +26,7 @@ on:
 
 jobs:
   build-docker:
-    runs-on: ${{ inputs.runner-label }}
+    runs-on: ${{ fromJSON(inputs.runner-label) }}
     steps:
       - name: Clean up old runs
         run: |

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -18,7 +18,7 @@ on:
       runner-label:
         required: false
         type: string
-        default: "mi-250"
+        default: '["mi-250"]'
       artifact-prefix:
         required: false
         default: 'plugin_wheels'
@@ -31,7 +31,7 @@ on:
 
 jobs:
   build-plugin-wheels:
-    runs-on: ${{ inputs.runner-label }}
+    runs-on: ${{ fromJSON(inputs.runner-label) }}
     steps:
       - name: Clean up old runs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       #       fails with a complaint abou the pipes module.
       python-versions: "3.11,3.12"
       rocm-version: ${{ matrix.rocm-version }}
+      runner-label: '["linux-x86-64-1gpu-amd-gfx942"]'
     secrets:
       rbe_ci_cert: ${{ secrets.RBE_CI_CERT }}
       rbe_ci_key: ${{ secrets.RBE_CI_KEY }}
@@ -37,9 +38,10 @@ jobs:
     uses: ./.github/workflows/build-docker.yml
     with:
       rocm-version: ${{ matrix.rocm-version }}
+      runner-label: '["linux-x86-64-1gpu-amd-gfx942"]'
   run-python-unit-tests:
     needs: call-build-docker
-    runs-on: mi-250
+    runs-on: "linux-x86-64-1gpu-amd-gfx942"
     timeout-minutes: 60
     strategy:
       matrix:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,11 +24,11 @@ jobs:
         rocm-version: ["7.1.0", "7.2.0"]
         include:
           - rocm-version: "7.1.0"
-            runner-label: "mi-250"
+            runner-label: '["linux-x86-64-1gpu-amd-gfx942"]'
           - rocm-version: "7.2.0"
             rocm-build-job: "compute-rocm-dkms-no-npi-hipclang"
             rocm-build-num: "16849"
-            runner-label: "internal"
+            runner-label: '["internal"]'
     uses: ./.github/workflows/build-wheels.yml
     with:
       python-versions: "3.11,3.12"
@@ -47,11 +47,11 @@ jobs:
         rocm-version: ["7.1.0", "7.2.0"]
         include:
           - rocm-version: "7.1.0"
-            runner-label: "mi-250"
+            runner-label: '["linux-x86-64-1gpu-amd-gfx942"]'
           - rocm-version: "7.2.0"
             rocm-build-job: "compute-rocm-dkms-no-npi-hipclang"
             rocm-build-num: "16849"
-            runner-label: "internal"
+            runner-label: '["linux-x86-64-1gpu-amd-gfx942"]'
     uses: ./.github/workflows/build-docker.yml
     with:
       rocm-version: ${{ matrix.rocm-version }}
@@ -64,9 +64,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        test-command:
+          - "python jax_rocm_plugin/build/rocm/run_single_gpu.py -c -s"
+          - "python jax_rocm_plugin/build/rocm/run_multi_gpu.py -c -s"
         rocm-version: ["7.1.0", "7.2.0"]
         ubuntu-version: ["22", "24"]
         include:
+          - test-command: "python jax_rocm_plugin/build/rocm/run_single_gpu.py -c -s"
+            runner-label: '["linux-x86-64-1gpu-amd-gfx942"]'
+          - test-command: "python jax_rocm_plugin/build/rocm/run_multi_gpu.py -c -s"
+            runner-label: '["linux-x86-64-4gpu-amd-gfx942"]'
           - rocm-version: "7.2.0"
             rocm-build-num: "16849"
     uses: ./.github/workflows/test-and-upload.yml
@@ -76,6 +83,7 @@ jobs:
       rocm-build-num: ${{ matrix.rocm-build-num || '0' }}
       github-sha: ${{ github.sha }}
       github-run-id: ${{ github.run_id }}
+      test-command: ${{ matrix.test-command }}
     secrets:
       ROCM_JAX_DB_HOSTNAME: ${{ secrets.ROCM_JAX_DB_HOSTNAME }}
       ROCM_JAX_DB_USERNAME: ${{ secrets.ROCM_JAX_DB_USERNAME }}

--- a/.github/workflows/test-and-upload.yml
+++ b/.github/workflows/test-and-upload.yml
@@ -19,6 +19,16 @@ on:
       github-run-id:
         required: true
         type: string
+      runner-label:
+        required: false
+        type: string
+        default: '["mi-250"]'
+      test-cmd:
+        required: false
+        type: string
+        default: >
+          python jax_rocm_plugin/build/rocm/run_single_gpu.py -c -s
+          && python jax_rocm_plugin/build/rocm/run_multi_gpu.py -c -s
     secrets:
       ROCM_JAX_DB_HOSTNAME:
         required: true
@@ -31,7 +41,7 @@ on:
 
 jobs:
   run-tests:
-    runs-on: mi-250
+    runs-on: ${{ fromJSON(inputs.runner-label) }}
     steps:
       - name: Change owners for cleanup
         run: |
@@ -68,7 +78,6 @@ jobs:
       - name: Run tests
         env:
           GPU_COUNT: "8"
-          GFX: "gfx90a"
           ROCM_VERSION: ${{ inputs.rocm-version }}
           UBUNTU_VERSION: ${{ inputs.ubuntu-version }}
           GITHUB_SHA: ${{ inputs.github-sha }}
@@ -76,8 +85,7 @@ jobs:
           # (charleshofer) TODO: Switch to RBE once we're able to process the test log information
           python3 build/ci_build test \
             "ghcr.io/rocm/jax-ubu${UBUNTU_VERSION}.rocm${ROCM_VERSION//.}:${GITHUB_SHA}" \
-            --test-cmd "python jax_rocm_plugin/build/rocm/run_single_gpu.py -c -s && \
-                        python jax_rocm_plugin/build/rocm/run_multi_gpu.py -c -s"
+            --test-cmd "${{ inputs.test-command }}"
       - name: Upload logs to artifact (per-matrix)
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Motivation

CI runners with 1 and 4 GPUs were added to our repo. Use them in our CI workflows.

## Technical Details

Modifies the workflows in `.github/workflows/` to use the `linux-x86-64-4gpu-amd-gfx942` for building and testing, and `linux-x86-64-1gpu-amd-gfx942` runners for testing. Builds with pre-released ROCm still have to happen on our `internal` runner since the cluster doesn't have access to Rastra BMS.

## Test Plan

Make sure that the ci.yml and nightly.yml pass and that nightly puts test data in the dashboard.

## Test Result

<!-- Briefly summarize test outcomes. -->
