### PR TITLE
Refactor and update skip reason categorization rules

### DIFF
--- a/ci/upload_test_to_db.py
+++ b/ci/upload_test_to_db.py
@@ -431,7 +431,8 @@ def upload_pytest_results(  # pylint: disable=too-many-arguments, too-many-local
             f, c, n = nodeid_parts(nodeid)
             test_id = test_id_map[(f, c, n)]
 
-            # Categorize skip reason, with special check for Mosaic in filename/testname (including mgpu)
+            # Categorize skip reason, with special check for Mosaic
+            # in filename/testname (including mgpu)
             skip_label = None
             if outcome == "skipped":
                 # Check if "mosaic" or "mgpu" is in filename or test name


### PR DESCRIPTION
## Motivation

Skip categories were not accurate. This PR aims to improve the categorization.

## Technical Details

Categories:
TPU-Only - Separated from Device Inapplicability
Not Supported on ROCm - More specific ROCm category
Multiple Devices Required - Separated from Device Inapplicability
NVIDIA-Specific - New category for CUDA/NVIDIA tests (moved from Missing Module)
Apple-Specific - For Metal/Apple Silicon tests
CPU-Only - Separated from Device Inapplicability
Too Slow (Skipped Upstream) - Performance-related skips
Currently Unmaintained (Skipped Upstream) - Maintenance-related skips

Also updated the order so we get some skips properly. 


## Test Plan

Will start a nightly. 

## Test Result

In progess. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
