### PR TITLE
Fix typo in test-and-upload argument name

### DIFF
--- a/.github/workflows/test-and-upload.yml
+++ b/.github/workflows/test-and-upload.yml
@@ -23,7 +23,7 @@ on:
         required: false
         type: string
         default: '["mi-250"]'
-      test-cmd:
+      test-command:
         required: false
         type: string
         default: >


### PR DESCRIPTION
Fix a the argument name introduced in https://github.com/ROCm/rocm-jax/pull/252 to match how it's used by the nightly job