### PR TITLE
Change ROCm labels to 'Not supported on ROCm'

### DIFF
--- a/ci/upload_test_to_db.py
+++ b/ci/upload_test_to_db.py
@@ -155,9 +155,9 @@ _RULES_RAW = [
     # Mosaic (check reason only, filename/testname checked separately)
     {"contains": "mosaic", "label": "Mosaic"},
     # ROCm-specific checks
-    {"any": ["skip on rocm", "skip for rocm"], "label": "Skipped on ROCm"},
-    {"all": ["not supported on", "rocm"], "label": "Skipped on ROCm"},
-    {"contains": "is not available for rocm", "label": "Skipped on ROCm"},
+    {"any": ["skip on rocm", "skip for rocm"], "label": "Not Supported on ROCm"},
+    {"all": ["not supported on", "rocm"], "label": "Not Supported on ROCm"},
+    {"contains": "is not available for rocm", "label": "Not Supported on ROCm"},
     # Multiple devices required (before generic "support" check)
     {"all": [">=", "devices"], "label": "Multiple Devices Required"},
     {"all": ["test", "requires", "device"], "label": "Multiple Devices Required"},


### PR DESCRIPTION
## Motivation

update ROCm labels to Not supported on ROCm. 

## Technical Details

update ROCm labels to Not supported on ROCm. 

## Test Plan

Local test done
## Test Result

Categorization successful
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
