### PR TITLE
Run single and multi GPU tests in parallel and upload combined results

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,9 +62,6 @@ jobs:
       matrix:
         rocm-version: ["7.1.0", "7.2.0"]
         ubuntu-version: ["22", "24"]
-        include:
-          - rocm-version: "7.2.0"
-            rocm-build-num: "16849"
     uses: ./.github/workflows/test-and-upload.yml
     with:
       rocm-version: ${{ matrix.rocm-version }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rocm-version: ["7.1.0", "7.2.0"]
+        rocm-version: ["7.1.1", "7.2.0"]
         ubuntu-version: ["22", "24"]
     uses: ./.github/workflows/test-and-upload.yml
     with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,18 +60,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-command:
-          - "python jax_rocm_plugin/build/rocm/run_single_gpu.py -c -s"
-          - "python jax_rocm_plugin/build/rocm/run_multi_gpu.py -c -s"
-        rocm-version: ["7.1.1", "7.2.0"]
+        rocm-version: ["7.1.0", "7.2.0"]
         ubuntu-version: ["22", "24"]
         include:
-          - test-command: "python jax_rocm_plugin/build/rocm/run_single_gpu.py -c -s"
-            runner-label: '["linux-x86-64-1gpu-amd"]'
-            test-id: "single"
-          - test-command: "python jax_rocm_plugin/build/rocm/run_multi_gpu.py -c -s"
-            runner-label: '["linux-x86-64-4gpu-amd"]'
-            test-id: "multi"
+          - rocm-version: "7.2.0"
+            rocm-build-num: "16849"
     uses: ./.github/workflows/test-and-upload.yml
     with:
       rocm-version: ${{ matrix.rocm-version }}
@@ -79,9 +72,6 @@ jobs:
       rocm-build-num: ${{ matrix.rocm-build-num || '0' }}
       github-sha: ${{ github.sha }}
       github-run-id: ${{ github.run_id }}
-      runner-label: ${{ matrix.runner-label }}
-      test-command: ${{ matrix.test-command }}
-      test-id: ${{ matrix.test-id }}
     secrets:
       ROCM_JAX_DB_HOSTNAME: ${{ secrets.ROCM_JAX_DB_HOSTNAME }}
       ROCM_JAX_DB_USERNAME: ${{ secrets.ROCM_JAX_DB_USERNAME }}

--- a/.github/workflows/test-and-upload.yml
+++ b/.github/workflows/test-and-upload.yml
@@ -159,7 +159,7 @@ jobs:
           ROCM_VERSION: ${{ inputs.rocm-version }}
           UBUNTU_VERSION: ${{ inputs.ubuntu-version }}
           LOGS_DIR: >-
-            logs-${{ inputs.test-id }}_${{ inputs.ubuntu-version }}_${{ inputs.rocm-version }}
+            logs-_${{ inputs.ubuntu-version }}_${{ inputs.rocm-version }}
           GITHUB_SHA: ${{ inputs.github-sha }}
           GITHUB_RUN_ID: ${{ inputs.github-run-id }}
           ROCM_BUILD_NUM: ${{ inputs.rocm-build-num }}

--- a/.github/workflows/test-and-upload.yml
+++ b/.github/workflows/test-and-upload.yml
@@ -67,7 +67,7 @@ jobs:
           docker pull "$IMAGE"
       - name: Run single GPU tests
         env:
-          GPU_COUNT: "8"
+          GPU_COUNT: "1"
           ROCM_VERSION: ${{ inputs.rocm-version }}
           UBUNTU_VERSION: ${{ inputs.ubuntu-version }}
           GITHUB_SHA: ${{ inputs.github-sha }}
@@ -119,7 +119,7 @@ jobs:
           docker pull "$IMAGE"
       - name: Run multi GPU tests
         env:
-          GPU_COUNT: "8"
+          GPU_COUNT: "4"
           ROCM_VERSION: ${{ inputs.rocm-version }}
           UBUNTU_VERSION: ${{ inputs.ubuntu-version }}
           GITHUB_SHA: ${{ inputs.github-sha }}

--- a/.github/workflows/test-and-upload.yml
+++ b/.github/workflows/test-and-upload.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   run-tests-single:
-    runs-on: ["linux-x86-64-1gpu-amd-gfx942"]
+    runs-on: ["linux-x86-64-1gpu-amd"]
     steps:
       - name: Change owners for cleanup
         run: |
@@ -75,7 +75,7 @@ jobs:
           # (charleshofer) TODO: Switch to RBE once we're able to process the test log information
           python3 build/ci_build test \
             "ghcr.io/rocm/jax-ubu${UBUNTU_VERSION}.rocm${ROCM_VERSION//.}:${GITHUB_SHA}" \
-            --test-cmd "python jax_rocm_plugin/build/rocm/run_single_gpu.py -c -s"
+            --test-cmd "ulimit -c 0 && python jax_rocm_plugin/build/rocm/run_single_gpu.py -c -s"
       - name: Upload logs to artifact (single)
         if: always()
         uses: actions/upload-artifact@v4
@@ -83,7 +83,7 @@ jobs:
           name: logs-${{ inputs.ubuntu-version }}_${{ inputs.rocm-version }}_single
           path: logs/
   run-tests-multi:
-    runs-on: ["linux-x86-64-4gpu-amd-gfx942"]
+    runs-on: ["linux-x86-64-4gpu-amd"]
     steps:
       - name: Change owners for cleanup
         run: |
@@ -98,7 +98,7 @@ jobs:
           # TODO: Change the repo and ref once we figure out how exactly we're going to
           #       manage tests
           repository: rocm/jax
-          ref: rocm-jaxlib-v0.8.0
+          ref: rocm-jaxlib-v0.8.2
           path: jax
       - name: Apply patches to rocm/jax test repo
         run: |
@@ -127,7 +127,7 @@ jobs:
           # (charleshofer) TODO: Switch to RBE once we're able to process the test log information
           python3 build/ci_build test \
             "ghcr.io/rocm/jax-ubu${UBUNTU_VERSION}.rocm${ROCM_VERSION//.}:${GITHUB_SHA}" \
-            --test-cmd "python jax_rocm_plugin/build/rocm/run_multi_gpu.py -c -s"
+            --test-cmd "ulimit -c 0 && python jax_rocm_plugin/build/rocm/run_multi_gpu.py -c -s"
       - name: Upload logs to artifact (multi)
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-and-upload.yml
+++ b/.github/workflows/test-and-upload.yml
@@ -19,19 +19,6 @@ on:
       github-run-id:
         required: true
         type: string
-      runner-label:
-        required: false
-        type: string
-      test-id:
-        description: 'Unique identifier for the test (e.g., single_gpu, multi_gpu)'
-        required: true
-        type: string
-      test-command:
-        required: false
-        type: string
-        default: >
-          python jax_rocm_plugin/build/rocm/run_single_gpu.py -c -s
-          && python jax_rocm_plugin/build/rocm/run_multi_gpu.py -c -s
     secrets:
       ROCM_JAX_DB_HOSTNAME:
         required: true
@@ -43,8 +30,8 @@ on:
         required: true
 
 jobs:
-  run-tests:
-    runs-on: ${{ fromJSON(inputs.runner-label) }}
+  run-tests-single:
+    runs-on: ["linux-x86-64-1gpu-amd-gfx942"]
     steps:
       - name: Change owners for cleanup
         run: |
@@ -78,7 +65,7 @@ jobs:
         run: |
           IMAGE="ghcr.io/rocm/jax-ubu${UBUNTU_VERSION}.rocm${ROCM_VERSION//.}:${GITHUB_SHA}"
           docker pull "$IMAGE"
-      - name: Run tests
+      - name: Run single GPU tests
         env:
           GPU_COUNT: "8"
           ROCM_VERSION: ${{ inputs.rocm-version }}
@@ -88,24 +75,81 @@ jobs:
           # (charleshofer) TODO: Switch to RBE once we're able to process the test log information
           python3 build/ci_build test \
             "ghcr.io/rocm/jax-ubu${UBUNTU_VERSION}.rocm${ROCM_VERSION//.}:${GITHUB_SHA}" \
-            --test-cmd "ulimit -c 0 && ${{ inputs.test-command }}"
-      - name: Upload logs to artifact (per-matrix)
+            --test-cmd "python jax_rocm_plugin/build/rocm/run_single_gpu.py -c -s"
+      - name: Upload logs to artifact (single)
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: logs-${{ inputs.test-id }}_${{ inputs.ubuntu-version }}_${{ inputs.rocm-version }}
+          name: logs-${{ inputs.ubuntu-version }}_${{ inputs.rocm-version }}_single
+          path: logs/
+  run-tests-multi:
+    runs-on: ["linux-x86-64-4gpu-amd-gfx942"]
+    steps:
+      - name: Change owners for cleanup
+        run: |
+          docker run --rm -v "./:/rocm-jax" ubuntu \
+            /bin/bash -c "shopt -s dotglob; chown -R $UID /rocm-jax/* || true"
+      - name: Checkout plugin repo
+        uses: actions/checkout@v4
+      - name: Checkout JAX repo
+        uses: actions/checkout@v4
+        with:
+          # TODO: Load the ref from a file that sets the min and max JAX version
+          # TODO: Change the repo and ref once we figure out how exactly we're going to
+          #       manage tests
+          repository: rocm/jax
+          ref: rocm-jaxlib-v0.8.0
+          path: jax
+      - name: Apply patches to rocm/jax test repo
+        run: |
+          pushd jax
+          git apply ../ci/patches/*
+          popd
+      - name: Authenticate to GitHub Container Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Pull images
+        env:
+          ROCM_VERSION: ${{ inputs.rocm-version }}
+          UBUNTU_VERSION: ${{ inputs.ubuntu-version }}
+          GITHUB_SHA: ${{ inputs.github-sha }}
+        run: |
+          IMAGE="ghcr.io/rocm/jax-ubu${UBUNTU_VERSION}.rocm${ROCM_VERSION//.}:${GITHUB_SHA}"
+          docker pull "$IMAGE"
+      - name: Run multi GPU tests
+        env:
+          GPU_COUNT: "8"
+          ROCM_VERSION: ${{ inputs.rocm-version }}
+          UBUNTU_VERSION: ${{ inputs.ubuntu-version }}
+          GITHUB_SHA: ${{ inputs.github-sha }}
+        run: |
+          # (charleshofer) TODO: Switch to RBE once we're able to process the test log information
+          python3 build/ci_build test \
+            "ghcr.io/rocm/jax-ubu${UBUNTU_VERSION}.rocm${ROCM_VERSION//.}:${GITHUB_SHA}" \
+            --test-cmd "python jax_rocm_plugin/build/rocm/run_multi_gpu.py -c -s"
+      - name: Upload logs to artifact (multi)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-${{ inputs.ubuntu-version }}_${{ inputs.rocm-version }}_multi
           path: logs/
   upload-to-db:
-    needs: run-tests
+    needs: [run-tests-single, run-tests-multi]
     runs-on: mysqldb
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
-      - name: Download logs from artifact (per-matrix)
+      - name: Download logs from artifact (single)
         uses: actions/download-artifact@v4
         with:
-          name: logs-${{ inputs.test-id }}_${{ inputs.ubuntu-version }}_${{ inputs.rocm-version }}
-          path: logs-${{ inputs.test-id }}_${{ inputs.ubuntu-version }}_${{ inputs.rocm-version }}
+          name: logs-${{ inputs.ubuntu-version }}_${{ inputs.rocm-version }}_single
+          path: logs-${{ inputs.ubuntu-version }}_${{ inputs.rocm-version }}
+      - name: Download logs from artifact (multi)
+        uses: actions/download-artifact@v4
+        with:
+          name: logs-${{ inputs.ubuntu-version }}_${{ inputs.rocm-version }}_multi
+          path: logs-${{ inputs.ubuntu-version }}_${{ inputs.rocm-version }}
       - name: Upload logs to MySQL database
         env:
           ROCM_JAX_DB_HOSTNAME: ${{ secrets.ROCM_JAX_DB_HOSTNAME }}
@@ -128,7 +172,7 @@ jobs:
           python ci/upload_test_to_db.py \
           --logs_dir "$LOGS_DIR" \
           --run-tag "ci-run" \
-          --runner-label "linux-x86-64-1gpu-amd" \
+          --runner-label "MI300" \
           --ubuntu-version "${UBUNTU_VERSION}" \
           --rocm-version "${ROCM_VERSION//.}" \
           --commit-sha "$GITHUB_SHA" \


### PR DESCRIPTION
Previously, each uploaded log represented a full test suite run (single+multi GPU). To preserve this model while enabling parallel execution, single and multi GPU tests are now run as separate parallel jobs and their results are combined before uploading.