### PR TITLE
Pick wheel below 0.46 to fix fixwheel ImportError

### DIFF
--- a/jax_rocm_plugin/build/build.py
+++ b/jax_rocm_plugin/build/build.py
@@ -399,9 +399,6 @@ async def main():
 
     args = parser.parse_args()
 
-    if args.rbe:
-        args.bazel_startup_options.append("--bazelrc=/jax_rocm_plugin/rbe.bazelrc")
-
     logger.info("%s", BANNER)
 
     if args.verbose:


### PR DESCRIPTION
A newly released `wheel>=0.46` removes `wheel.cli` module, which is still imported by `fixwheel.py`. This causes the error:
```
  File "/jax_rocm_plugin/build/rocm/tools/fixwheel.py", line 66, in fix_wheel
    from wheel.cli import tags
ModuleNotFoundError: No module named 'wheel.cli'
ERROR:__main__:Subprocess failed with error: Command '['python', '/jax_rocm_plugin/build/rocm/tools/fixwheel.py', 