### PR TITLE
Partially revert "CI: Added timeout on selfhosted GHA runners (#240)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
   run-python-unit-tests:
     needs: call-build-docker
     runs-on: "linux-x86-64-1gpu-amd"
+    timeout-minutes: 60
     strategy:
       matrix:
         rocm-version: ["7.1.0"]


### PR DESCRIPTION
Performance CI runs can exceed 1 hour and fail due to the enforced timeout.