### PR TITLE
Load rbe.bazelrc when --rbe is set

### DIFF
--- a/jax_rocm_plugin/build/rocm/tools/build_wheels.py
+++ b/jax_rocm_plugin/build/rocm/tools/build_wheels.py
@@ -344,7 +344,7 @@ def fix_wheel(path, jax_path):
         # NOTE(mrodden): auditwheel 6.0 added lddtree module, but 6.3.0 changed
         # the fuction to ldd and also changed its behavior
         # constrain range to 6.0 to 6.2.x
-        cmd = ["pip", "install", "auditwheel>=6,<6.3", "wheel<0.46"]
+        cmd = ["pip", "install", "auditwheel>=6,<6.3", "wheel"]
         subprocess.run(cmd, check=True, env=env)
 
         fixwheel_path = os.path.join(jax_path, "build/rocm/tools/fixwheel.py")


### PR DESCRIPTION
After removing the implicit `rbe.bazelrc` import (See https://github.com/ROCm/rocm-jax/pull/247), `--config=rocm_rbe` is no longer defined in this build path.
```
ERROR: Config value 'rocm_rbe' is not defined in any .rc file
```
This change explicitly loads `rbe.bazelrc` via Bazel startup options when `--rbe` is enabled.