### PR TITLE
Re-enable original detailed abort detection in UTs

### DIFF
--- a/jax_rocm_plugin/build/rocm/run_single_gpu.py
+++ b/jax_rocm_plugin/build/rocm/run_single_gpu.py
@@ -47,8 +47,6 @@ LAST_CODE = 0
 BASE_DIR = "./logs"
 ALL_CRASHED_TESTS = []  # Global list to track all crashed tests
 
-ENABLE_ABORT_DETECTION = False
-
 
 def sanitize_for_json(text):
     """Remove control characters that break JSON parsing.
@@ -1160,7 +1158,6 @@ def _generate_html_template(template_data):
         </html>"""
 
 
-# pylint: disable=too-many-return-statements
 def check_for_crash(last_running_file):
     """Check if a crash occurred and return crash info.
 
@@ -1172,10 +1169,6 @@ def check_for_crash(last_running_file):
     2. The file has valid JSON with test information
     3. The test was marked as "running" but never completed
     """
-    if not ENABLE_ABORT_DETECTION:
-        clear_crash_file(last_running_file)
-        return None
-
     if not os.path.exists(last_running_file):
         # File doesn't exist = no crash (test completed normally)
         return None
@@ -1239,9 +1232,6 @@ def check_for_crash(last_running_file):
 
 def handle_abort(json_file, html_file, last_running_file, testfile, crash_info=None):
     """Handle crash detection and append info to reports."""
-    if not ENABLE_ABORT_DETECTION:
-        clear_crash_file(last_running_file)
-        return False
     if crash_info is None:
         crash_info = check_for_crash(last_running_file)
 


### PR DESCRIPTION
After the original detailed abort detection was merged, temporary guards were added to accommodate CI run limits. Following validation via nightly testing,

https://github.com/ROCm/rocm-jax/actions/runs/21231792758
https://github.com/ROCm/rocm-jax/actions/runs/21233910851
https://github.com/ROCm/rocm-jax/actions/runs/21239647389
https://github.com/ROCm/rocm-jax/actions/runs/21241365229

This PR removes the temporary guards and restores the original detailed abort detection behavior (See PR https://github.com/ROCm/rocm-jax/pull/250).