### PR TITLE
Fix rocm performance script and prepare for 0.9.0 jax plugin release

### DIFF
--- a/.github/workflows/rocm-perf.yml
+++ b/.github/workflows/rocm-perf.yml
@@ -42,12 +42,20 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
+      - name: Checkout JAX repo for jaxlib build
+        uses: actions/checkout@v4
+        with:
+          repository: ROCm/jax
+          ref: rocm-jaxlib-v0.8.2
+          path: jax
+
       - name: Build plugin wheels
         run: |
           python3 build/ci_build \
             --compiler clang \
             --python-versions $PYTHON_VERSION \
             --rocm-version $ROCM_VERSION \
+            --jax-source-dir="./jax" \
             dist_wheels
 
       - name: Copy wheels for Docker build context


### PR DESCRIPTION
## Motivation

This pr fixes:

1) rocm perf script issue with jaxlib building
2) also prepares for 0.9.0 release and install the necessary package

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
