### PR TITLE
Update Llama custom performance workload to support JAX 0.8.2+

### DIFF
--- a/.github/workflows/llama-perf.yml
+++ b/.github/workflows/llama-perf.yml
@@ -258,6 +258,9 @@ jobs:
             apt update && apt install -y libglib2.0-0
             export EXECUTOR="base_executor_config"
             export TRAIN_SETTING="${{ matrix.model-name }}"
+            export XLA_FLAGS="--xla_gpu_enable_latency_hiding_scheduler=True \
+                                --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True \
+                                --xla_gpu_enable_command_buffer='' --xla_gpu_autotune_level=4"
             bash -i bazel_run_anynode.sh 2>&1 | tee logs.log
             tail -n 25 logs.log > training_summary.txt'
       - name: Upload training summary


### PR DESCRIPTION
This PR updates the Llama custom performance workload to support JAX 0.8.2+. Bazel is fixed at version 8.5.0, as Bazel 9.0.0's stricter rules currently break the workload. TransformerEngine (TE) is pinned to a fixed commit to stabilize benchmarking results and will be revisited in a future update. Additionally, some XLA flags added to improve runtime stability for the workload.

PS. The workflow now also supports providing the TE commit as a manual input.