### PR TITLE
make env var paths independent of ROCm version

### DIFF
--- a/docker/Dockerfile.base-ubu22
+++ b/docker/Dockerfile.base-ubu22
@@ -8,7 +8,7 @@ ARG GPU_DEVICE_TARGETS="gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1
 # The ROCm version to be used inside the container.
 ARG ROCM_VERSION
 # The installation path for ROCm.
-ARG ROCM_PATH=/opt/rocm-${ROCM_VERSION}
+ARG ROCM_PATH=/opt/rocm
 # The ROCm build job ID for pre-release installations.
 ARG ROCM_BUILD_JOB
 # The ROCm build number for pre-release installations.
@@ -74,8 +74,8 @@ RUN --mount=type=cache,target=/var/cache/apt   \
 ENV GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS}
 ENV ROCM_PATH=${ROCM_PATH}
 ENV PATH="$PATH:/opt/rocm/bin:/opt/rocm/llvm/bin"
-ENV LD_LIBRARY_PATH="/opt/rocm-${ROCM_VERSION}/lib:${LD_LIBRARY_PATH}"
-ENV LLVM_PATH="/opt/rocm-${ROCM_VERSION}/llvm"
+ENV LD_LIBRARY_PATH="/opt/rocm/lib:${LD_LIBRARY_PATH}"
+ENV LLVM_PATH="/opt/rocm/llvm"
 
 ENV HCC_HOME="$ROCM_PATH/hcc"
 ENV HIP_PATH="$ROCM_PATH/"

--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -6,7 +6,7 @@ ARG GPU_DEVICE_TARGETS="gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1
 # The ROCm version to be used inside the container.
 ARG ROCM_VERSION
 # The installation path for ROCm.
-ARG ROCM_PATH=/opt/rocm-${ROCM_VERSION}
+ARG ROCM_PATH=/opt/rocm
 # The ROCm build job ID for pre-release installations.
 ARG ROCM_BUILD_JOB
 # The ROCm build number for pre-release installations.
@@ -62,8 +62,8 @@ RUN --mount=type=cache,target=/var/cache/apt   \
 ### Set Docker Environment
 ENV PATH="$PATH:/opt/rocm/bin:/opt/rocm/llvm/bin"
 # ENV ln -s "/opt/rocm-${ROCM_RELEASE}/lib/librocblas.so.5" "/opt/rocm-${ROCM_RELEASE}/lib/librocblas.so.4"
-ENV LD_LIBRARY_PATH="/opt/rocm-${ROCM_VERSION}/lib:$LD_LIBRARY_PATH"
-ENV LLVM_PATH="/opt/rocm-${ROCM_VERSION}/llvm"
+ENV LD_LIBRARY_PATH="/opt/rocm/lib:$LD_LIBRARY_PATH"
+ENV LLVM_PATH="/opt/rocm/llvm"
 ENV ROCM_PATH=${ROCM_PATH}
 ENV GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS}
 ENV HCC_HOME=$ROCM_PATH/hcc


### PR DESCRIPTION
## Motivation

A mismatch in LLVM_PATH or ROCM_PATH based on the minor version breaks logic in XLA where we look for tools such as `ld.lld` 

## Technical Details

This PR fixes such issues by using the symlink path instead which is stable across versions. 

## Test Plan

Once the docker is built a simple code snippet such as 

```python 
import jax.numpy as jnp
print(jnp.ones(5))
```

Should work successfully, if the path is not set correctly, this will fail. 

## Test Result


## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
