### PR TITLE
Use wheel 0.46.3 in fixwheel.py

### DIFF
--- a/jax_rocm_plugin/build/rocm/tools/build_wheels.py
+++ b/jax_rocm_plugin/build/rocm/tools/build_wheels.py
@@ -344,7 +344,7 @@ def fix_wheel(path, jax_path):
         # NOTE(mrodden): auditwheel 6.0 added lddtree module, but 6.3.0 changed
         # the fuction to ldd and also changed its behavior
         # constrain range to 6.0 to 6.2.x
-        cmd = ["pip", "install", "auditwheel>=6,<6.3", "wheel<0.46"]
+        cmd = ["pip", "install", "auditwheel>=6,<6.3", "wheel>=0.46.3"]
         subprocess.run(cmd, check=True, env=env)
 
         fixwheel_path = os.path.join(jax_path, "build/rocm/tools/fixwheel.py")


### PR DESCRIPTION
There's a [security vulnerability](https://www.sentinelone.com/vulnerability-database/cve-2026-24049/) in `wheel==0.46.2`. This change moves us up to version 0.46.3 or higher to get the fix for it. However, the `wheel.cli` Python interface was removed in version 0.46.3. So, also convert the places where `wheel` is used to use the CLI via `subprocess` instead of the Python interface.