### PR TITLE
0.8.2 ci_build to check dev tarball

### DIFF
--- a/build/ci_build
+++ b/build/ci_build
@@ -295,9 +295,9 @@ def build_dockers(
     commit_info = _get_commit_info_from_wheel()
     dockerfiles = _apply_filters(docker_filters, "Dockerfile.jax")
 
-    # Docker tags cannot contain '+', so replace it with '_'
-    rocm_ver_tag = "rocm%s" % "".join(rocm_version.split(".")).replace("+", "_")
-    rocm_version_tag = "".join(rocm_version.split(".")).replace("+", "_")
+    # Docker tags cannot contain '+', so replace it with '.' for consistency with wheel versions
+    rocm_ver_tag = "rocm%s" % "".join(rocm_version.split(".")).replace("+", ".")
+    rocm_version_tag = "".join(rocm_version.split(".")).replace("+", ".")
     plugin_namespace = rocm_version[0]
     if plugin_namespace == "6":
         plugin_namespace = "60"
@@ -374,8 +374,8 @@ def build_base_dockers(
     push_latest=False,
 ):
     dockerfiles = _apply_filters(docker_filters, "Dockerfile.base")
-    # Docker tags cannot contain '+', so replace it with '_'
-    rocm_ver_tag = "rocm%s" % "".join(rocm_version.split(".")).replace("+", "_")
+    # Docker tags cannot contain '+', so replace it with '.' for consistency with wheel versions
+    rocm_ver_tag = "rocm%s" % "".join(rocm_version.split(".")).replace("+", ".")
 
     extra_args = []
     if add_llvm:

--- a/jax_rocm_plugin/build/rocm/ci_build
+++ b/jax_rocm_plugin/build/rocm/ci_build
@@ -48,8 +48,8 @@ def dist_wheels(
         xla_path = os.path.abspath(xla_path)
 
     # create manylinux image with requested ROCm installed
-    # Docker tags cannot contain '+', so replace it with '_'
-    image = "jax-manylinux_2_28_x86_64_rocm%s" % rocm_version.replace(".", "").replace("+", "_")
+    # Docker tags cannot contain '+', so replace it with '.' for consistency with wheel versions
+    image = "jax-manylinux_2_28_x86_64_rocm%s" % rocm_version.replace(".", "").replace("+", ".")
 
     # Try removing the Docker image.
     try:
@@ -151,7 +151,6 @@ def dist_wheels(
             "-e",
             "GIT_WORK_TREE=/repo",
             "-e",
-            # Replace '+' with '.' for PEP 440 compliance (local version label)
             "ROCM_VERSION_EXTRA=" + rocm_version.replace("+", "."),
             image,
             "bash",

--- a/jax_rocm_plugin/build/rocm/tools/build_wheels.py
+++ b/jax_rocm_plugin/build/rocm/tools/build_wheels.py
@@ -240,7 +240,8 @@ def build_jaxlib_wheel(
         "--verbose",
         "--bazel_options=--action_env=HIPCC_COMPILE_FLAGS_APPEND=--offload-compress",
         "--bazel_options=--repo_env=ML_WHEEL_TYPE=release",
-        f"--bazel_options=--repo_env=ML_WHEEL_VERSION_SUFFIX=+rocm{version_string}",
+        # Replace '+' with '.' for PEP 440 compliance (local version label)
+        f"--bazel_options=--repo_env=ML_WHEEL_VERSION_SUFFIX=+rocm{rocm_version.replace('+', '.')}",
     ]
 
     # Add clang path if clang is used.

--- a/jax_rocm_plugin/build/rocm/tools/get_rocm.py
+++ b/jax_rocm_plugin/build/rocm/tools/get_rocm.py
@@ -29,6 +29,7 @@ import shutil
 import ssl
 import subprocess
 import sys
+import urllib.parse
 import urllib.request
 
 # pylint: disable=unspecified-encoding
@@ -222,8 +223,8 @@ def _install_therock(rocm_version, therock_path):
     else:
         os.makedirs(rocm_real_path)
         tar_path = "/tmp/therock.tar.gz"
-        # URL-encode the '+' character as '%2B' (required for HTTP requests)
-        encoded_url = therock_path.replace("+", "%2B")
+        # URL-encode special characters (e.g., '+' becomes '%2B')
+        encoded_url = urllib.parse.quote(therock_path, safe=":/?&=")
         with urllib.request.urlopen(encoded_url) as response:
             if response.status == 200:
                 with open(tar_path, "wb") as tar_file:


### PR DESCRIPTION
## Motivation

Fix `packaging.version.InvalidVersion` errors during JAX wheel builds caused by ROCm version strings containing multiple `+` characters (e.g., `7.12.0.dev0+<sha>`), which violate PEP 440 version specifier rules.

## Technical Details

Modified `jax_rocm_plugin/build/rocm/ci_build` to sanitize `rocm_version` by replacing `+` with `.` for PEP 440 compliance:

1. **Line 60**: Sanitize when setting `ML_WHEEL_VERSION_SUFFIX` for Bazel jaxlib builds
2. **Line 178**: Sanitize when setting `ROCM_VERSION_EXTRA` environment variable for plugin/pjrt wheel builds

PEP 440 local version identifiers only allow one `+` character, and the local segment can only contain alphanumerics and periods. This ensures wheel versions like `0.8.0+rocm7.12.0.dev0.6475192225f38160e614c71cc0543aed2be8fa03` are valid.

## Test Plan

- Build JAX wheels with dev rocm_version containing `+` (e.g., `7.12.0.dev0+6475192225f38160e614c71cc0543aed2be8fa03`)
- Verify jaxlib, jax-rocm7-plugin, and jax-rocm7-pjrt wheels build successfully
- Verify wheel filenames contain sanitized version strings

## Test Result

- All three wheels build without `InvalidVersion` errors
- Wheel filenames correctly use `.` instead of second `+` in version string
- https://github.com/ROCm/TheRock/actions/runs/21718314934

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Cherry-picked from: https://github.com/ROCm/rocm-jax/pull/292