### PR TITLE
Update runner labels in Llama perf workflow

### DIFF
--- a/.github/workflows/llama-perf.yml
+++ b/.github/workflows/llama-perf.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   build-te-wheels:
-    runs-on: build-only-jax
+    runs-on: linux-jax-mi355-1
     outputs:
       runner_label: ${{ steps.arch.outputs.label }}
       te_commit_sha: ${{ steps.tsha.outputs.hash }}


### PR DESCRIPTION
This PR updates the runners used in the Llama performance workflow after recent label changes in infrastructure.