### PR TITLE
Fix broken nightly and PR CI workflow files

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -92,7 +92,7 @@ jobs:
             --rocm-build-num="${{ inputs.rocm-build-num }}" \
             --jax-source-dir="./jax" \
             dist_wheels \
-            --rbe
+            --rbe \
             --builder-image="${{ inputs.builder-image }}"
       - name: Archive plugin wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
       python-versions: "3.11,3.12,3.13,3.14"
       rocm-version: ${{ matrix.rocm-version }}
       runner-label: '["linux-x86-64-1gpu-amd"]'
+      builder-image: "search"
     secrets:
       rbe_ci_cert: ${{ secrets.RBE_CI_CERT }}
       rbe_ci_key: ${{ secrets.RBE_CI_KEY }}
-      builder-image: "search"
   call-build-docker:
     needs: call-build-wheels
     strategy:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,10 +34,10 @@ jobs:
       rocm-build-job: ${{ matrix.rocm-build-job }}
       rocm-build-num: ${{ matrix.rocm-build-num }}
       runner-label: ${{ matrix.runner-label }}
+      builder-image: "search"
     secrets:
       rbe_ci_cert: ${{ secrets.RBE_CI_CERT }}
       rbe_ci_key: ${{ secrets.RBE_CI_KEY }}
-      builder-image: "search"
   call-build-docker:
     needs: call-build-wheels
     strategy:

--- a/jax_rocm_plugin/build/rocm/ci_build
+++ b/jax_rocm_plugin/build/rocm/ci_build
@@ -31,9 +31,6 @@ def dist_wheels(
     python_versions,
     xla_path,
     jax_path,
-    rocm_build_job,
-    rocm_build_num,
-    therock_path,
     rbe,
     compiler,
     builder_image,
@@ -70,7 +67,6 @@ def dist_wheels(
         bw_cmd.append("--rbe")
 
     bw_cmd.append(container_plugin_path)
-    bw_cmd.append("/jax")
     container_cmd = " ".join(bw_cmd)
 
     cmd = ["docker", "run"]
@@ -225,9 +221,6 @@ def main():
             args.python_versions,
             args.xla_source_dir,
             args.jax_source_dir,
-            args.rocm_build_job,
-            args.rocm_build_num,
-            args.therock_path,
             args.rbe,
             args.compiler,
             args.builder_image,


### PR DESCRIPTION
I busted nightly and PR CI with the merge of https://github.com/ROCm/rocm-jax/pull/209. The `builder-image` argument should have been in the `inputs`, not the `secrets`.
