### PR TITLE
Add dynamic git repository, make it possible to override jax/xla deps…

### DIFF
--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -8,35 +8,19 @@
 # limitations under the License.
 
 # buildifier: disable=module-docstring
-load("//third_party:repo.bzl", "amd_http_archive")
+load("//third_party:repo.bzl", "dynamic_git_repository")
 
-# To update XLA to a new revision,
-# a) update XLA_COMMIT to the new git commit hash
-# b) get the sha256 hash of the commit by running:
-#    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
-#    and update XLA_SHA256 with the result.
+# To update XLA to a new revision, update XLA_COMMIT to the new git commit hash.
+# To temporarily override at build time without editing this file:
+#   bazel build --repo_env=XLA_COMMIT_OVERRIDE=<commit> //...
+#   bazel build --repo_env=XLA_COMMIT_OVERRIDE=<url>@<commit> //...
 
 XLA_COMMIT = "24c5f10ae8fc24aefd20b43c501ade7f66fd0cfd"
-XLA_SHA256 = "f00db8761e86bcb51b52e64bc983717181050c8752c040e33ecb1429d861c30b"
 
 def repo():
-    amd_http_archive(
+    dynamic_git_repository(
         name = "xla",
-        sha256 = XLA_SHA256,
-        strip_prefix = "xla-{commit}".format(commit = XLA_COMMIT),
-        urls = ["https://github.com/ROCm/xla/archive/{commit}.tar.gz".format(commit = XLA_COMMIT)],
+        remote = "https://github.com/ROCm/xla.git",
+        commit = XLA_COMMIT,
         patch_file = [],
     )
-
-    # For development, one often wants to make changes to the TF repository as well
-    # as the JAX repository. You can override the pinned repository above with a
-    # local checkout by either:
-    # a) overriding the TF repository on the build.py command line by passing a flag
-    #    like:
-    #    python build/build.py build --local_xla_path=/path/to/xla
-    #    or
-    # b) by commenting out the http_archive above and uncommenting the following:
-    # local_repository(
-    #    name = "xla",
-    #    path = "/path/to/xla",
-    # )


### PR DESCRIPTION
## Motivation
It simplifies the CI workflows if we can override bazel dependencies through the env variables.
For instance building rocm-jax plugins and executing tests in jax upstream repo is much easier
when we can take the jax and xla commits from the jax repo and use them when calling the tests with plugin.
It provided the possibility to apply the patches automatically as well as eliminating the need for a separate checkouts.

