### PR TITLE
Log in before wheel builds to avoid public GHCR rate limit

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -75,6 +75,10 @@ jobs:
           repository: ${{ inputs.jax-repo }}
           ref: ${{ inputs.jax-ref }}
           path: jax
+      - name: Authenticate to GitHub Container Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Get RBE cluster keys
         env:
           RBE_CI_CERT: ${{ secrets.rbe_ci_cert }}


### PR DESCRIPTION
We've been hitting the rate limit on Docker pulls in our CI builds, see https://github.com/ROCm/rocm-jax/actions/runs/22145728776/job/64031917207?pr=315#step:7:118. GHCR limits unauthenticated public artifact pulls to 60 per hour. However, the limit for authenticated pulls is in the thousands, see https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-authenticated-users. This change adds a `docker login` and authenticates with the action token. This should let us use the higher rate limit.