### PR TITLE
Build custom MIOpen from source to fix kernel initialization crashes

### DIFF
--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -123,6 +123,9 @@ RUN [ "$ROCM_VERSION" = "7.1.1" ] || (       \
         nlohmann-json3-dev                     \
         build-essential                        \
         cmake &&                               \
+    # prevent apt and ldconf to override the symlinks
+    dpkg-divert --no-rename --remove /opt/rocm/lib/libMIOpen.so.1 && \
+    dpkg-divert --add --package local --divert /opt/rocm/lib/libMIOpen.bak.1.0.70200 --rename /opt/rocm/lib/libMIOpen.so.1.0.70200 && \
     cd /rocm-libraries/projects/miopen/ && mkdir build && cd build && \
     export CXX=amdclang++ &&                                          \
     cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DMIOPEN_BACKEND=HIP     \


### PR DESCRIPTION
## Motivation

JAX workloads are experiencing critical kernel initialization crashes with the standard MIOpen library shipped with ROCm. An upstream fix has been developed in https://github.com/ROCm/rocm-libraries/pull/4472 but is not yet available in any official ROCm release.

This PR implements a temporary workaround by building MIOpen from source using the `fix/stack-overflow-kernel-init` branch. The custom build is skipped for ROCm 7.1.1 where the fix branch does not compile.

This should be removed once the upstream fix is available in an official ROCm release that can be installed via deb packages or TheRock.

## Technical Details

Adds a build step in `docker/Dockerfile.base-ubu24` that clones the `ROCm/rocm-libraries` repository, installs build dependencies (Boost, GTest, nlohmann-json, CMake), compiles MIOpen with HIP backend, and installs it to `/opt/rocm`. Build dependencies are left installed to avoid potential issues.

The build is conditionally skipped for ROCm 7.1.1 using `[ "$ROCM_VERSION" = "7.1.1" ] || (...)`. Additionally, sets `MIOPEN_FIND_ENFORCE=SEARCH_DB_UPDATE` to mitigate kernel database crashes.

MIOpen is configured with MLIR and AI features disabled for trim dependencies:
`-DMIOPEN_USE_MLIR=OFF -DMIOPEN_ENABLE_AI_KERNEL_TUNING=OFF -DMIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK=OFF`.

The patch uses dpkg-divert to prevent `apt` and `ldconfig` from over-writing the symlinks pointing to the manually installed `libMIOpen.so.1`.

## Test Plan

Build the base-ubu24 image for ROCm versions != 7.1.1 and verify MIOpen is installed. Run pytest and verify no kernel initialization crashes occur. Confirm the build is properly skipped for ROCm 7.1.1.

## Test Results

**As Expected**: No kernel initialization crashes, successful pytest runs on 7.2.0, and proper conditional build behavior for ROCm 7.1.1.


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
