### PR TITLE
Install Bazel into Ubuntu base images

### DIFF
--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -138,6 +138,14 @@ RUN [ "$ROCM_VERSION" = "7.1.1" ] || (       \
 # This mitigates crashes related to the kernel database.
 ENV MIOPEN_FIND_ENFORCE=SEARCH_DB_UPDATE
 
+# Install Bazel
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt install apt-transport-https curl gnupg -y && \
+    curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-archive-keyring.gpg && \
+    mv bazel-archive-keyring.gpg /usr/share/keyrings && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list && \
+    apt update && apt install bazel -y
+
 ### Set Docker Environment
 ENV PATH="$PATH:/opt/rocm/bin:/opt/rocm/llvm/bin"
 # ENV ln -s "/opt/rocm-${ROCM_RELEASE}/lib/librocblas.so.5" "/opt/rocm-${ROCM_RELEASE}/lib/librocblas.so.4"


### PR DESCRIPTION
We use the base image in upstream CI, and upstream CI needs Bazel. Install it in the base image.

TODO:
- [ ] Maybe make this optional like Clang? Or use the base image as a base for an "upstream" image?