### PR TITLE
Change the rocm version and model for llama_perf workflow

### DIFF
--- a/.github/workflows/llama-perf.yml
+++ b/.github/workflows/llama-perf.yml
@@ -292,11 +292,11 @@ jobs:
         include:
           - jax-version: "0.6.0"
             model-name: "train_dense"
-            rocm-version: "7.0.2"
+            rocm-version: "7.2.0"
             python-version: "3.12"
           - jax-version: "0.8.2"
             model-name: "train_dense"
-            rocm-version: "7.1.1"
+            rocm-version: "7.2.0"
             python-version: "3.12"
     steps:
       - name: Checkout plugin repo


### PR DESCRIPTION
## Motivation

We want to used rocm 7,2.0+ and byllama model for regression tests going forward. This PR introduces both changes. 

## Test

The modified workflow has been tested: https://github.com/ROCm/rocm-jax/actions/runs/22191741840/