### PR TITLE
Fix: Add `vim-common` package to manylinux Docker image for XLA build

### DIFF
--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
@@ -7,7 +7,7 @@ ENV GPU_DEVICE_TARGETS="gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx11
 
 # Install patchelf and headers for numactl
 RUN --mount=type=cache,target=/var/cache/dnf \
-    dnf install -y patchelf numactl-devel
+    dnf install -y patchelf numactl-devel vim-common
 
 # Install ROCm
 RUN --mount=type=cache,target=/var/cache/dnf \

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -7,7 +7,7 @@ ENV GPU_DEVICE_TARGETS="gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx11
 
 # Install patchelf and headers for numactl
 RUN --mount=type=cache,target=/var/cache/dnf \
-    dnf install -y patchelf numactl-devel
+    dnf install -y patchelf numactl-devel vim-common
 
 # Install ROCm
 RUN --mount=type=cache,target=/var/cache/dnf \

--- a/jax_rocm_plugin/build/rocm/build_wheels/Dockerfile.manylinux_2_28_x86_64.rocm
+++ b/jax_rocm_plugin/build/rocm/build_wheels/Dockerfile.manylinux_2_28_x86_64.rocm
@@ -5,10 +5,6 @@ ARG ROCM_BUILD_JOB
 ARG ROCM_BUILD_NUM
 ARG THEROCK_PATH
 
-# Install system GCC and C++ libraries, and build deps
-RUN --mount=type=cache,target=/var/cache/dnf \
-    dnf install -y patchelf numactl-devel
-
 RUN --mount=type=cache,target=/var/cache/dnf \
     --mount=type=bind,source=build/rocm/tools/get_rocm.py,target=get_rocm.py \
     --mount=type=bind,from=therock,target=/tmp/therock/ \
@@ -20,7 +16,7 @@ RUN printf '%s\n' > /opt/rocm/bin/target.lst ${GPU_DEVICE_TARGETS}
 
 # Install LLVM 18 and dependencies.
 RUN --mount=type=cache,target=/var/cache/dnf \
-    dnf install -y patchelf numactl-devel python3.11 python3.11-devel python3.11-pip wget && \
+    dnf install -y patchelf numactl-devel vim-common python3.11 python3.11-devel python3.11-pip wget && \
     rm -f /usr/bin/python3 && ln -sf /usr/bin/python3.11 /usr/bin/python3 && \
     rm -f /usr/bin/pip3 && ln -sf /usr/bin/pip3.11 /usr/bin/pip3 && \
     python3.11 -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
## Motivation

The JAX ROCm plugin wheel build fails with the following error:

```
ERROR: /root/.cache/bazel/_bazel_root/.../external/xla/xla/backends/gpu/target_config/BUILD:25:12: 
Executing genrule @@xla//xla/backends/gpu/target_config:embed_gpu_specs_gen failed: (Exit 127)

/bin/bash: line 35: xxd: command not found

Target //pjrt/tools:build_gpu_plugin_wheel failed to build
```

The XLA build process includes a genrule (`@@xla//xla/backends/gpu/target_config:embed_gpu_specs_gen`) that embeds GPU specification files into C++ code using the `xxd` utility. The `xxd` command is used to convert binary/text files into C-style hex arrays:

```bash
xxd -i "${src}" | sed -e "s/^unsigned char [^[]*/static const unsigned char ${VAR_NAME}/" ...
```

The `xxd` utility is not installed in the manylinux builder Docker image, causing the build to fail.

### Solution

Add the `vim-common` package to the manylinux Dockerfile. On RHEL/AlmaLinux-based systems (which `manylinux_2_28` is based on), `xxd` is provided by the `vim-common` package.


## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
