### PR TITLE
Install AWS CLI v2 to ROCm image

### DIFF
--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -87,6 +87,16 @@ RUN --mount=type=cache,target=/var/cache/apt \
     # Disable credentials to enable access to public GCS buckets from upstream without requiring login
     gcloud config set auth/disable_credentials True
 
+# Install AWS CLI v2
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && \
+    apt-get install -y --no-install-recommends curl unzip && \
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip && \
+    unzip -q /tmp/awscliv2.zip -d /tmp && \
+    /tmp/aws/install && \
+    rm -rf /tmp/aws /tmp/awscliv2.zip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Install ROCm:
 RUN --mount=type=bind,source=tools/get_rocm.py,target=get_rocm.py \
     --mount=type=cache,target=/var/cache/apt \


### PR DESCRIPTION
This PR adds AWS CLI v2 to ROCm image. It is needed for interacting with S3 logs/artifacts from CI jobs. It uses the official AWS CLI v2 installer (curl + unzip), avoids distro awscli v1 packaging.