### PR TITLE
Shrink docker image size

### DIFF
--- a/build/ci_build
+++ b/build/ci_build
@@ -670,6 +670,7 @@ def parse_args():
         "--llvm-version",
         help="Set the version number of LLVM to be installed.",
         type=int,
+        default="18",
     )
 
     testp = subp.add_parser("test")

--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -93,7 +93,7 @@ RUN --mount=type=bind,source=tools/get_rocm.py,target=get_rocm.py \
     --mount=type=bind,from=therock,target=/tmp/therock/ \
     python3 get_rocm.py --rocm-version=$ROCM_VERSION --job-name=$ROCM_BUILD_JOB --build-num=$ROCM_BUILD_NUM --therock-path=$THEROCK_PATH
 
-# Install LLVM when enabled:
+# Install LLVM's clang and lld when enabled:
 RUN --mount=type=cache,target=/var/cache/apt   \
     [ $INSTALL_LLVM -eq 0 ] || (               \
     apt update &&                              \
@@ -105,7 +105,7 @@ RUN --mount=type=cache,target=/var/cache/apt   \
     cd /tmp &&                                 \
     wget https://apt.llvm.org/llvm.sh &&       \
     chmod +x llvm.sh &&                        \
-    ./llvm.sh $LLVM_VERSION all &&             \
+    ./llvm.sh $LLVM_VERSION clang lld &&       \
     rm llvm.sh &&                              \
     apt-get clean && rm -rf /var/lib/apt/lists/* )
 
@@ -133,7 +133,7 @@ RUN [ "$ROCM_VERSION" = "7.1.1" ] || (       \
           -DMIOPEN_USE_MLIR=OFF -DMIOPEN_ENABLE_AI_KERNEL_TUNING=OFF  \
           -DMIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK=OFF .. &&            \
     make -j10 && make install &&                                      \
-    apt-get clean && rm -rf /var/lib/apt/lists/* )
+    rm -rf /rocm-libraries && apt-get clean && rm -rf /var/lib/apt/lists/* )
 
 # This mitigates crashes related to the kernel database.
 ENV MIOPEN_FIND_ENFORCE=SEARCH_DB_UPDATE


### PR DESCRIPTION
## Motivation

The base image size is quite large, around 40GB. The size makes it difficult to work with in CI and for local development. It takes a long time to pull, and it takes up a lot of space on dev and CI machines. We can shrink it down by installing only the LLVM components that we need and by removing the very large rocm-libraires repo that we use to build MIOpen.

## Technical Details

Only install LLVM clang and lld, and remove the rocm-libraries source code after the MIOpen build is finished.

