### PR TITLE
Fix symlink creation for newer builds of TheRock

### DIFF
--- a/jax_rocm_plugin/build/rocm/tools/get_rocm.py
+++ b/jax_rocm_plugin/build/rocm/tools/get_rocm.py
@@ -31,7 +31,6 @@ import subprocess
 import sys
 import urllib.request
 
-
 # pylint: disable=unspecified-encoding
 LOG = logging.getLogger(__name__)
 
@@ -218,11 +217,14 @@ def _install_therock(rocm_version, therock_path):
     os.symlink(rocm_real_path, rocm_sym_path, target_is_directory=True)
 
     # Make a symlink to amdgcn to fix LLVM not being able to find binaries
-    os.symlink(
-        rocm_real_path + "/lib/llvm/amdgcn/",
-        rocm_real_path + "/amdgcn",
-        target_is_directory=True,
-    )
+    try:
+        os.symlink(
+            rocm_real_path + "/lib/llvm/amdgcn/",
+            rocm_real_path + "/amdgcn",
+            target_is_directory=True,
+        )
+    except FileExistsError:
+        LOG.info("%s already exists", rocm_sym_path)
 
 
 def _setup_internal_repo(system, rocm_version, job_name, build_num):
@@ -396,8 +398,7 @@ def setup_repos_el8(rocm_version_str):
         rocm_version_str = "%d.%d" % (rv.major, rv.minor)
 
     with open("/etc/yum.repos.d/rocm.repo", "w") as rfd:
-        rfd.write(
-            """
+        rfd.write("""
 [ROCm]
 name=ROCm
 baseurl=http://repo.radeon.com/rocm/rhel8/%s/main
@@ -406,9 +407,7 @@ gpgcheck=1
 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
 timeout=1000
 minrate=1
-"""
-            % rocm_version_str
-        )
+""" % rocm_version_str)
 
     with open("/etc/yum.repos.d/amdgpu.repo", "w") as afd:
         if rocm_version_str.startswith("7"):
@@ -417,8 +416,7 @@ minrate=1
         else:
             repodir = "amdgpu"
             rhel_minor = 8
-        afd.write(
-            """
+        afd.write("""
 [amdgpu]
 name=amdgpu
 baseurl=https://repo.radeon.com/%s/%s/rhel/8.%d/main/x86_64/
@@ -427,9 +425,7 @@ gpgcheck=1
 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
 timeout=1000
 minrate=1
-"""
-            % (repodir, rocm_version_str, rhel_minor)
-        )
+""" % (repodir, rocm_version_str, rhel_minor))
 
 
 def parse_args():


### PR DESCRIPTION
Earlier versions of ROCm 7 were missing a link to amdgcn, so we created the link when we installed ROCm via the `get_rocm.py` script. However, on newer builds of TheRock, the link is there. If amdgcn already exists, the link creation fails and causes the build script to fail when it doesn't need to. Just wrap the link creation in a `try` block so the ROCm install continues.

rocm-jaxlib-v0.8.0 is an old branch whose wheels have already been released, but TheRock continues to build from it for testing.