### PR TITLE
Add AWS CLI to manylinux image

### DIFF
--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
@@ -28,3 +28,14 @@ COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang++.cfg
 COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang.cfg
 COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang++.cfg
 COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang.cfg
+
+# Install AWS CLI v2
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && \
+    apt-get install -y --no-install-recommends curl unzip && \
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip && \
+    unzip -q /tmp/awscliv2.zip -d /tmp && \
+    /tmp/aws/install && \
+    rm -rf /tmp/aws /tmp/awscliv2.zip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -29,3 +29,13 @@ COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang.cfg
 COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang++.cfg
 COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang.cfg
 
+# Install AWS CLI v2
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && \
+    apt-get install -y --no-install-recommends curl unzip && \
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip && \
+    unzip -q /tmp/awscliv2.zip -d /tmp && \
+    /tmp/aws/install && \
+    rm -rf /tmp/aws /tmp/awscliv2.zip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+


### PR DESCRIPTION
## Motivation

Adds the AWS CLI client to the manylinux images. We need to use the maylinux builder image in upstream CI's continuous workflow. This job will push the wheels it builds to an S3 bucket in AWS, and we need the AWS client to do that.

## Technical Details

Add a build step to the manylinux Dockerfiles that installs the AWS CLI.