### PR TITLE
Update default repo for Jax CI test tesults to DB workflow

### DIFF
--- a/ci/ingest_jax_ci_logs.sh
+++ b/ci/ingest_jax_ci_logs.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 : "${INPUT_GPU_ARCH:?}"
-: "${FILTER_REPO:=ROCm/jax}"
+: "${FILTER_REPO:=jax-ml/jax}"
 : "${FILTER_RUN_ID:=}"
 
 ROOT="jax-ci-test-logs/${FILTER_REPO}/"


### PR DESCRIPTION
This PR updates the default `FILTER_REPO` in `ingest_jax_ci_logs.sh`. The target repository is changed, so scheduled runs should search this repo first by default.