### PR TITLE
Adding user specified post release number and no-rocm-version-extra arguments

### DIFF
--- a/build/ci_build
+++ b/build/ci_build
@@ -186,6 +186,8 @@ def dist_wheels(
     rbe=False,
     compiler="gcc",
     builder_image=None,
+    wheel_post_release=None,
+    include_rocm_version_extra=True,
 ):
     jax_plugin_dir = "jax_rocm_plugin"
 
@@ -227,6 +229,12 @@ def dist_wheels(
 
     if rbe:
         cmd.append("--rbe")
+
+    if wheel_post_release is not None:
+        cmd.append("--wheel-post-release=%s" % wheel_post_release)
+
+    if not include_rocm_version_extra:
+        cmd.append("--no-rocm-version-extra")
 
     cmd.append("dist_wheels")
     subprocess.check_call(cmd, cwd=jax_plugin_dir)
@@ -619,6 +627,17 @@ def parse_args():
         default="clang",
         help="Compiler backend to use when compiling jax/jaxlib",
     )
+    p.add_argument(
+        "--wheel-post-release",
+        type=int,
+        default=None,
+        help="Optional post-release suffix number to append as .postX",
+    )
+    p.add_argument(
+        "--no-rocm-version-extra",
+        action="store_true",
+        help="Do not append local '+rocm...' version tag to plugin/PJRT wheels",
+    )
 
     subp = p.add_subparsers(dest="action", required=True)
 
@@ -718,6 +737,8 @@ def main():
             rbe=args.rbe,
             compiler=args.compiler,
             builder_image=args.builder_image,
+            wheel_post_release=args.wheel_post_release,
+            include_rocm_version_extra=not args.no_rocm_version_extra,
         )
 
     if args.action == "build_dockers":

--- a/jax_rocm_plugin/build/rocm/ci_build
+++ b/jax_rocm_plugin/build/rocm/ci_build
@@ -49,6 +49,8 @@ def dist_wheels(
     rbe,
     compiler,
     builder_image,
+    wheel_post_release=None,
+    include_rocm_version_extra=True,
 ):
     if xla_path:
         xla_path = os.path.abspath(xla_path)
@@ -80,6 +82,9 @@ def dist_wheels(
 
     if rbe:
         bw_cmd.append("--rbe")
+
+    if wheel_post_release is not None:
+        bw_cmd.extend(["--wheel-post-release", str(wheel_post_release)])
 
     bw_cmd.append(container_plugin_path)
     container_cmd = " ".join(bw_cmd)
@@ -116,7 +121,8 @@ def dist_wheels(
             "--shm-size",
             "64G",
             "-e",
-            "ROCM_VERSION_EXTRA=" + rocm_version,
+            "ROCM_VERSION_EXTRA="
+            + (rocm_version.replace("+", ".") if include_rocm_version_extra else ""),
             "-e",
             "ROCM_JAX_COMMIT=" + rocm_jax_commit,
             builder_image,
@@ -217,6 +223,17 @@ def parse_args():
         "--builder-image",
         default=None,
     )
+    p.add_argument(
+        "--wheel-post-release",
+        type=int,
+        default=None,
+        help="Optional post-release suffix number to append as .postX",
+    )
+    p.add_argument(
+        "--no-rocm-version-extra",
+        action="store_true",
+        help="Do not append local '+rocm...' version tag to plugin/PJRT wheels",
+    )
 
     subp = p.add_subparsers(dest="action", required=True)
 
@@ -240,6 +257,8 @@ def main():
             args.rbe,
             args.compiler,
             args.builder_image,
+            args.wheel_post_release,
+            not args.no_rocm_version_extra,
         )
 
     elif args.action == "test":

--- a/jax_rocm_plugin/build/rocm/tools/build_wheels.py
+++ b/jax_rocm_plugin/build/rocm/tools/build_wheels.py
@@ -147,6 +147,7 @@ def build_plugin_wheel(
     rbe=False,
     compiler="gcc",
     wheels="jax-rocm-plugin,jax-rocm-pjrt",
+    wheel_post_release=None,
 ):
     """Build ROCm plugin and/or PJRT wheels via jax_rocm_plugin/build/build.py.
 
@@ -202,6 +203,9 @@ def build_plugin_wheel(
     env = dict(os.environ)
     env["JAX_RELEASE"] = str(1)
     env["JAXLIB_RELEASE"] = str(1)
+    env.pop("WHEEL_POST_RELEASE", None)
+    if wheel_post_release is not None:
+        env["WHEEL_POST_RELEASE"] = str(wheel_post_release)
     env["PATH"] = "%s:%s" % (py_bin, env["PATH"])
 
     LOG.info("Running %r from cwd=%r", cmd, plugin_path)
@@ -338,6 +342,14 @@ def to_cpy_ver(python_version):
     return "cp%d%d" % (int(tup[0]), int(tup[1]))
 
 
+def validate_wheel_post_release(post_release):
+    """Validate optional post-release number for wheel versions."""
+    if post_release is None:
+        return
+    if post_release <= 0:
+        raise ValueError("--wheel-post-release must be a positive integer")
+
+
 def fix_wheel(path, jax_path):
     """Fix auditwheel compliance using fixwheel.py and auditwheel."""
     try:
@@ -410,6 +422,12 @@ def parse_args():
         default="gcc",
         help="Compiler backend to use when compiling jax/jaxlib",
     )
+    p.add_argument(
+        "--wheel-post-release",
+        type=int,
+        default=None,
+        help="Optional post-release suffix number to append as .postX",
+    )
 
     p.add_argument(
         "plugin_path", help="Directory where JAX ROCm plugin source is located"
@@ -434,6 +452,7 @@ def find_wheels(path):
 def main():
     """Main entry point."""
     args = parse_args()
+    validate_wheel_post_release(args.wheel_post_release)
     python_versions = args.python_versions.split(",")
 
     manylinux_output_dir = "dist_manylinux"
@@ -481,6 +500,7 @@ def main():
         args.rbe,
         args.compiler,
         wheels="jax-rocm-pjrt",
+        wheel_post_release=args.wheel_post_release,
     )
     # Fix PJRT wheel.
     wheel_paths = find_wheels(full_output_path)
@@ -501,6 +521,7 @@ def main():
             args.rbe,
             args.compiler,
             wheels="jax-rocm-plugin",
+            wheel_post_release=args.wheel_post_release,
         )
         # Fix plugin wheels for this Python version.
         wheel_paths = find_wheels(full_output_path)

--- a/jax_rocm_plugin/jaxlib_ext/tools/build_utils.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_utils.py
@@ -25,6 +25,30 @@ import subprocess
 import glob
 import textwrap
 
+def _append_post_release_suffix(version: str, post_release: str) -> str:
+    """Return version with .postX inserted before any local suffix."""
+    public, sep, local = version.partition("+")
+    return (
+        f"{public}.post{post_release}+{local}"
+        if sep
+        else f"{public}.post{post_release}"
+    )
+
+
+def _apply_wheel_post_release(wheel_path: str, post_release: str | None) -> str:
+    """Append a .postX version suffix into wheel filename when requested."""
+    if not post_release:
+        return wheel_path
+    base = os.path.basename(wheel_path)
+    parts = base[:-4].split("-")
+    if len(parts) != 5:
+        raise ValueError(f"Unexpected wheel filename format: {base}")
+    parts[1] = _append_post_release_suffix(parts[1], post_release)
+    renamed = f"{'-'.join(parts)}.whl"
+    renamed_path = os.path.join(os.path.dirname(wheel_path), renamed)
+    os.rename(wheel_path, renamed_path)
+    return renamed_path
+
 
 def is_windows() -> bool:
     """Check if running on Windows platform."""
@@ -66,7 +90,9 @@ def build_wheel(
         cwd=sources_path,
         env=env,
     )
+    post_release = env.get("WHEEL_POST_RELEASE")
     for wheel in glob.glob(os.path.join(sources_path, "dist", "*.whl")):
+        wheel = _apply_wheel_post_release(wheel, post_release)
         output_file = os.path.join(output_path, os.path.basename(wheel))
         sys.stderr.write(f"Output wheel: {output_file}\n\n")
         sys.stderr.write(

--- a/jax_rocm_plugin/pjrt/tools/build_utils.py
+++ b/jax_rocm_plugin/pjrt/tools/build_utils.py
@@ -25,6 +25,30 @@ import subprocess
 import glob
 import textwrap
 
+def _append_post_release_suffix(version: str, post_release: str) -> str:
+    """Return version with .postX inserted before any local suffix."""
+    public, sep, local = version.partition("+")
+    return (
+        f"{public}.post{post_release}+{local}"
+        if sep
+        else f"{public}.post{post_release}"
+    )
+
+
+def _apply_wheel_post_release(wheel_path: str, post_release: str | None) -> str:
+    """Append a .postX version suffix into wheel filename when requested."""
+    if not post_release:
+        return wheel_path
+    base = os.path.basename(wheel_path)
+    parts = base[:-4].split("-")
+    if len(parts) != 5:
+        raise ValueError(f"Unexpected wheel filename format: {base}")
+    parts[1] = _append_post_release_suffix(parts[1], post_release)
+    renamed = f"{'-'.join(parts)}.whl"
+    renamed_path = os.path.join(os.path.dirname(wheel_path), renamed)
+    os.rename(wheel_path, renamed_path)
+    return renamed_path
+
 
 def is_windows() -> bool:
     """Check if running on Windows platform."""
@@ -65,7 +89,9 @@ def build_wheel(
         cwd=sources_path,
         env=env,
     )
+    post_release = env.get("WHEEL_POST_RELEASE")
     for wheel in glob.glob(os.path.join(sources_path, "dist", "*.whl")):
+        wheel = _apply_wheel_post_release(wheel, post_release)
         output_file = os.path.join(output_path, os.path.basename(wheel))
         sys.stderr.write(f"Output wheel: {output_file}\n\n")
         sys.stderr.write(


### PR DESCRIPTION
# Motivation
This PR enables publishing multiple fixed wheel artifacts for the same package version lineage (e.g., 0.9.1) while preserving semantic version constraints used by jax[rocm].

# Technical Details
Add end-to-end support for optional post-release wheel versions via --wheel-post-release across build/ci_build, jax_rocm_plugin/build/rocm/ci_build, and jax_rocm_plugin/build/rocm/tools/build_wheels.py.

- New CLI flag: --wheel-post-release added and forwarded across the three build entrypoints.
- build_wheels.py validates post-release input once (> 0) and exports it only when provided.
- pjrt/tools/build_utils.py and jaxlib_ext/tools/build_utils.py apply .postX to the wheel version segment in filenames (including before +local suffixes when present).
- No behavior change when --wheel-post-release is omitted.

## ROCm Version Extra Toggle
This PR also exposes a switch to control whether plugin/PJRT wheel versions include the local ROCm suffix (+rocm...).

- Default behavior: include ROCM_VERSION_EXTRA (current behavior).
- New opt-out flag: --no-rocm-version-extra.
- Plumbing: build/ci_build -> jax_rocm_plugin/build/rocm/ci_build -> container env ROCM_VERSION_EXTRA.
- Effect in setup scripts: when present, wheel/package version is suffixed with +rocm<value>; when disabled, that suffix is omitted.

# Test Plan
Build with default behavior (rocm version suffix included, post version excluded):

```
python3 build/ci_build \
  --python-versions="3.11,3.12,3.13,3.14" \
  --rocm-version=7.2.0 \
  dist_wheels
```

Build with post release number:
```
python3 build/ci_build \
  --python-versions="3.11,3.12,3.13,3.14" \
  --rocm-version=7.2.0 \
  --wheel-post-release=1 \
  dist_wheels
```

Build with suffix disabled:
```
python3 build/ci_build \
  --python-versions="3.11,3.12,3.13,3.14" \
  --rocm-version=7.2.0 \
  --no-rocm-version-extra \
  dist_wheels
```

# Test Result
Wheels are built successfully with the added flags.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
