### PR TITLE
Add manylinux2014 builder image

### DIFF
--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -112,6 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         rocm-version: ["7.1.1", "7.2.0"]
+        manylinux-plat-tag: ["manylinux2014", "manylinux_2_28"]
         include:
           - rocm-version: "7.1.1"
             runner-label: "linux-x86-64-1gpu-amd"
@@ -139,7 +140,8 @@ jobs:
             --rocm-version="${{ matrix.rocm-version }}" \
             --rocm-build-job="${{ matrix.rocm-build-job }}" \
             --rocm-build-num="${{ matrix.rocm-build-num }}" \
-            build_manylinux_dockers
+            build_manylinux_dockers \
+            --manylinux-plat-tag="${{ matrix.manylinux-plat-tag }}"
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -154,7 +156,7 @@ jobs:
           ROCM_BUILD_NUM: >-
             ${{ matrix.rocm-build-num && format('-{0}', inputs.rocm-build-num) || '' }}
         run: |
-          image_tag="ghcr.io/rocm/jax-manylinux_2_28-rocm-${ROCM_VERSION}${ROCM_BUILD_JOB}${ROCM_BUILD_NUM}"
+          image_tag="ghcr.io/rocm/jax-${{ matrix.manylinux-plat-tag }}-rocm-${ROCM_VERSION}${ROCM_BUILD_JOB}${ROCM_BUILD_NUM}"
 
           # Push with commit SHA tag
           sha_image_tag="${image_tag}:${GITHUB_SHA}"

--- a/build/ci_build
+++ b/build/ci_build
@@ -28,7 +28,7 @@ import json
 import re
 
 
-MANYLINUX_IMAGE_BASE_NAME = "ghcr.io/rocm/jax-manylinux_2_28"
+MANYLINUX_IMAGE_BASE_NAME = "ghcr.io/rocm/jax"
 
 
 def _get_labels(image_name):
@@ -129,10 +129,11 @@ def _docker_image_exists(image):
     return True
 
 
-def _construct_manylinux_builder_image_name(rocm_version, rocm_build_job="", rocm_build_num="", therock_path=None):
+def _construct_manylinux_builder_image_name(rocm_version, manylinux_plat_tag, rocm_build_job="", rocm_build_num="", therock_path=None):
     """Create an image name that includes the ROCm ersion, build job, build number, etc"""
-    return "{base_name}-{rocm_type}-{rocm_version}{rocm_build_job}{rocm_build_num}".format(
+    return "{base_name}-{manylinux_plat_tag}-{rocm_type}-{rocm_version}{rocm_build_job}{rocm_build_num}".format(
         base_name=MANYLINUX_IMAGE_BASE_NAME,
+        manylinux_plat_tag=manylinux_plat_tag,
         rocm_type="therock" if therock_path else "rocm",
         rocm_version=rocm_version,
         rocm_build_job="-%s" % rocm_build_job if rocm_build_job else "",
@@ -141,20 +142,20 @@ def _construct_manylinux_builder_image_name(rocm_version, rocm_build_job="", roc
 
 
 def build_manylinux_dockers(
-    rocm_version, rocm_build_job="", rocm_build_num="", therock_path=None, tag=None
+    rocm_version, rocm_build_job="", rocm_build_num="", therock_path=None, tag=None, manylinux_plat_tag="manylinux_2_28",
 ):
     """Build a manylinux image that can be used for building release-ready JAX wheels"""
     if tag:
         constructed_tag = tag
     else:
-        constructed_tag = _construct_manylinux_builder_image_name(rocm_version, rocm_build_job, rocm_build_num, therock_path)
+        constructed_tag = _construct_manylinux_builder_image_name(rocm_version, manylinux_plat_tag, rocm_build_job, rocm_build_num, therock_path)
 
     if therock_path:
         cmd = [
             "docker",
             "build",
             "-t=%s" % constructed_tag,
-            "--file=docker/manylinux/Dockerfile.jax-manylinux_2_28-therock",
+            "--file=docker/manylinux/Dockerfile.jax-%s-therock" % manylinux_plat_tag,
             "--build-arg=ROCM_VERSION=%s" % rocm_version,
             "--build-arg=THEROCK_PATH=%s" % therock_path,
             #"--build-context=%s" % therock_path,
@@ -165,7 +166,7 @@ def build_manylinux_dockers(
             "docker",
             "build",
             "-t=%s" % constructed_tag,
-            "--file=docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm",
+            "--file=docker/manylinux/Dockerfile.jax-%s-rocm" % manylinux_plat_tag,
             "--build-arg=ROCM_VERSION=%s" % rocm_version,
             "--build-arg=ROCM_BUILD_JOB=%s" % rocm_build_job,
             "--build-arg=ROCM_BUILD_NUM=%s" % rocm_build_num,
@@ -201,8 +202,8 @@ def dist_wheels(
         )
     # If builder-image is set to 'search', try and find one based off of the passed ROCm info
     elif local_builder_image == "search":
-        print("Searching for manylinux builder image...")
-        local_builder_image = _construct_manylinux_builder_image_name(rocm_version, rocm_build_job, rocm_build_num, therock_path)
+        print("Searching for manylinux_2_28 builder image...")
+        local_builder_image = _construct_manylinux_builder_image_name(rocm_version, "manylinux_2_28", rocm_build_job, rocm_build_num, therock_path)
         if not _docker_image_exists(local_builder_image):
             print(f"ERROR: Builder image '{local_builder_image}' does not exist")
             exit(1)
@@ -628,6 +629,9 @@ def parse_args():
     ml_parser.add_argument(
         "--tag", "-t", type=str, help="Override the default image name and tag"
     )
+    ml_parser.add_argument(
+        "--manylinux-plat-tag", "-m", type=str, help="manylinux platform to build the image from (e.g. 'manylinux_2_28' or 'manylinux2014')",
+    )
 
     dwp = subp.add_parser("dist_wheels")
     dwp.add_argument("--rbe", action="store_true", help="Use Bazel RBE for building")
@@ -707,6 +711,7 @@ def main():
             rocm_build_num=args.rocm_build_num,
             therock_path=args.therock_path,
             tag=args.tag,
+            manylinux_plat_tag=args.manylinux_plat_tag,
         )
 
     if args.action == "dist_wheels":

--- a/docker/manylinux/Dockerfile.jax-manylinux2014-rocm
+++ b/docker/manylinux/Dockerfile.jax-manylinux2014-rocm
@@ -1,0 +1,41 @@
+FROM quay.io/pypa/manylinux2014
+
+ARG ROCM_VERSION
+ARG ROCM_BUILD_JOB
+ARG ROCM_BUILD_NUM
+ENV GPU_DEVICE_TARGETS="gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1200 gfx1201"
+
+# Install patchelf and headers for numactl
+RUN --mount=type=cache,target=/var/cache/dnf \
+    yum install -y patchelf numactl-devel vim-common && \
+    yum clean all
+
+# Install ROCm
+RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=bind,source=./tools/get_rocm.py,target=get_rocm.py \
+    /opt/python/cp314-cp314/bin/python3 get_rocm.py --rocm-version=$ROCM_VERSION --job-name=$ROCM_BUILD_JOB --build-num=$ROCM_BUILD_NUM
+ENV PATH="$PATH:/opt/rocm/bin:/opt/rocm/llvm/bin"
+RUN printf '%s\n' > /opt/rocm/bin/target.lst ${GPU_DEVICE_TARGETS}
+
+# Install LLVM 18 and dependencies.
+RUN --mount=type=cache,target=/var/cache/dnf \
+    yum install -y wget && yum clean all
+RUN mkdir /tmp/llvm-project && wget -qO - https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-18.1.8.tar.gz | tar -xz -C /tmp/llvm-project --strip-components 1 && \
+    mkdir /tmp/llvm-project/build && cd /tmp/llvm-project/build && cmake -DLLVM_ENABLE_PROJECTS='clang;lld' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-18/ ../llvm && \
+    make -j$(nproc) && make -j$(nproc) install && rm -rf /tmp/llvm-project
+
+# Copy in our clang configuiration file
+COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang++.cfg
+COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang.cfg
+COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang++.cfg
+COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang.cfg
+
+# Install AWS CLI v2
+RUN --mount=type=cache,target=/var/cache/dnf \
+    yum install -y curl unzip && \
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip && \
+    unzip -q /tmp/awscliv2.zip -d /tmp && \
+    /tmp/aws/install && \
+    rm -rf /tmp/aws /tmp/awscliv2.zip && \
+    yum clean all
+


### PR DESCRIPTION
## Motivation

Upstream CI wants wheels to be compliant with manylinux2014. Previously, we've only built wheels for manylinux_2_28, and consequently we only have a builder Docker image based on manylinux_2_28. This change adds a new Dockerfile for builder images based on manylinux2014.

## Technical Details

In jax-ml/jax CI, there's a compliance check for manylinux2014 using `auditwheel` in the continuous job. In order to pass that check, we're going to have to build 

## Test Plan

1) Make sure that the build-base-dockers CI job builds the manylinux2014 image and pushes it to GHCR
2) Pull the built manylinux2014 and try to build the JAX plugin wheels with it

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
