### PR TITLE
Shrink manylinux image

### DIFF
--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y wget && dnf clean all
 RUN mkdir /tmp/llvm-project && wget -qO - https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-18.1.8.tar.gz | tar -xz -C /tmp/llvm-project --strip-components 1 && \
     mkdir /tmp/llvm-project/build && cd /tmp/llvm-project/build && cmake -DLLVM_ENABLE_PROJECTS='clang;lld' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-18/ ../llvm && \
-    make -j$(nproc) && make -j$(nproc) install && rm -rf /tmp/llvm-project
+    make -j$(nproc) && make -j$(nproc) install clang lld && rm -rf /tmp/llvm-project
 
 # Copy in our clang configuiration file
 COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang++.cfg

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -20,7 +20,7 @@ RUN printf '%s\n' > /opt/rocm/bin/target.lst ${GPU_DEVICE_TARGETS}
 RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y wget && dnf clean all
 RUN mkdir /tmp/llvm-project && wget -qO - https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-18.1.8.tar.gz | tar -xz -C /tmp/llvm-project --strip-components 1 && \
-    mkdir /tmp/llvm-project/build && cd /tmp/llvm-project/build && cmake -DLLVM_ENABLE_PROJECTS='clang;lld' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-18/ ../llvm && \
+    mkdir /tmp/llvm-project/build && cd /tmp/llvm-project/build clang lld && cmake -DLLVM_ENABLE_PROJECTS='clang;lld' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-18/ ../llvm && \
     make -j$(nproc) && make -j$(nproc) install && rm -rf /tmp/llvm-project
 
 # Copy in our clang configuiration file


### PR DESCRIPTION
Make the manylinux image a little smaller by only installing the components of LLVM that we need (clang and lld)