### PR TITLE
Remove gfx942 postfix from runner labels to align with K8s setup

### DIFF
--- a/.github/workflows/ci-ut.yml
+++ b/.github/workflows/ci-ut.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   build-and-test:
     name: build-and-test (${{ matrix.mode.name }})
-    runs-on: linux-x86-64-4gpu-amd-gfx942
+    runs-on: linux-x86-64-4gpu-amd
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly-rbe.yml
+++ b/.github/workflows/nightly-rbe.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-and-test:
-    runs-on: linux-x86-64-4gpu-amd-gfx942
+    runs-on: linux-x86-64-4gpu-amd
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
I believe the original intention was to use our K8s runner pool. The `-gfx942` postfix was intentionally removed from our K8s runner labels, so relying on it may unintentionally pin jobs to older runner groups. This PR updates the workflows to keep runner selection aligned with the current K8s setup.