### PR TITLE
fix: add rocm_sysdeps/lib to patchelf RUNPATH for wheel builds

### DIFF
--- a/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
@@ -236,7 +236,16 @@ def prepare_wheel_rocm(wheel_sources_path: pathlib.Path, *, cpu, rocm_version, s
         f"_triton.{pyext}",
         f"rocm_plugin_extension.{pyext}",
     ]
-    runpath = "$ORIGIN/../rocm/lib:$ORIGIN/../rocm/lib/rocm_sysdeps/lib:$ORIGIN/../../rocm/lib:$ORIGIN/../../rocm/lib/rocm_sysdeps/lib:/opt/rocm/lib:/opt/rocm/lib/rocm_sysdeps/lib"
+    runpath = ":".join(
+        [
+            "$ORIGIN/../rocm/lib",
+            "$ORIGIN/../rocm/lib/rocm_sysdeps/lib",
+            "$ORIGIN/../../rocm/lib",
+            "$ORIGIN/../../rocm/lib/rocm_sysdeps/lib",
+            "/opt/rocm/lib",
+            "/opt/rocm/lib/rocm_sysdeps/lib",
+        ]
+    )
     # patchelf --set-rpath $RUNPATH $so
     for f in files:
         so_path = os.path.join(plugin_dir, f)

--- a/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
+++ b/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
@@ -211,7 +211,16 @@ def prepare_rocm_plugin_wheel(
         raise RuntimeError(mesg) from ex
 
     shared_obj_path = os.path.join(plugin_dir, "xla_rocm_plugin.so")
-    runpath = "$ORIGIN/../rocm/lib:$ORIGIN/../rocm/lib/rocm_sysdeps/lib:$ORIGIN/../../rocm/lib:$ORIGIN/../../rocm/lib/rocm_sysdeps/lib:/opt/rocm/lib:/opt/rocm/lib/rocm_sysdeps/lib"
+    runpath = ":".join(
+        [
+            "$ORIGIN/../rocm/lib",
+            "$ORIGIN/../rocm/lib/rocm_sysdeps/lib",
+            "$ORIGIN/../../rocm/lib",
+            "$ORIGIN/../../rocm/lib/rocm_sysdeps/lib",
+            "/opt/rocm/lib",
+            "/opt/rocm/lib/rocm_sysdeps/lib",
+        ]
+    )
     # patchelf --set-rpath $RUNPATH $so
     fix_perms = False
     perms = os.stat(shared_obj_path).st_mode


### PR DESCRIPTION
- [x] Fix pylint `C0301: Line too long` issues in both wheel build scripts
- [x] Reformat `runpath` string construction using `":".join([...])` across multiple lines
- [x] Verify pylint (10/10) and black formatting pass