### PR TITLE
fix: add rocm_sysdeps/lib to patchelf RUNPATH for wheel builds

### DIFF
--- a/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
@@ -26,7 +26,6 @@ import stat
 import subprocess
 import tempfile
 
-
 # pylint: disable=import-error,invalid-name,consider-using-with
 from bazel_tools.tools.python.runfiles import runfiles
 from jaxlib_ext.tools import build_utils
@@ -106,14 +105,12 @@ def write_setup_cfg(setup_sources_path, cpu):
     tag = build_utils.platform_tag(cpu)
     cfg_path = setup_sources_path / "setup.cfg"
     with open(cfg_path, "w", encoding="utf-8") as f:
-        f.write(
-            f"""[metadata]
+        f.write(f"""[metadata]
 license_files = LICENSE.txt
 
 [bdist_wheel]
 plat_name={tag}
-"""
-        )
+""")
 
 
 def get_xla_commit_hash():

--- a/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
+++ b/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
@@ -30,7 +30,6 @@ import tempfile
 from bazel_tools.tools.python.runfiles import runfiles
 from pjrt.tools import build_utils
 
-
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--sources_path",
@@ -104,14 +103,12 @@ def write_setup_cfg(setup_sources_path, cpu):
     tag = build_utils.platform_tag(cpu)
     cfg_path = setup_sources_path / "setup.cfg"
     with open(cfg_path, "w", encoding="utf-8") as f:
-        f.write(
-            f"""[metadata]
+        f.write(f"""[metadata]
 license_files = LICENSE.txt
 
 [bdist_wheel]
 plat_name={tag}
-"""
-        )
+""")
 
 
 def get_xla_commit_hash():


### PR DESCRIPTION
- [x] Add `rocm_sysdeps/lib` to patchelf RUNPATH in wheel build scripts
- [x] Fix Black/lint formatting failures in modified files