### PR TITLE
Bump XLA to fix TheRock build

### DIFF
--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -16,8 +16,8 @@ load("//third_party:repo.bzl", "amd_http_archive")
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update XLA_SHA256 with the result.
 
-XLA_COMMIT = "d5cc96703778a828aba8e97b80e5057f4046c202"
-XLA_SHA256 = "6573fc97cfd3ebfee926442b1671be3d7b77148719ad52d69f20fcb7ed8d0d5c"
+XLA_COMMIT = "79c294ba619728537e8af7bc73f14f17433e1bc9"
+XLA_SHA256 = "ab0793bcf7eb6b11622c521a3294c6537714ccec76d97b2c15e28f209117db85"
 
 def repo():
     amd_http_archive(


### PR DESCRIPTION
## Summary
- Update XLA commit to `79c294ba619728537e8af7bc73f14f17433e1bc9` to fix the build with TheRock.

## Test plan
- [ ] CI builds pass with the updated XLA pin