### PR TITLE
Rebuild ROCR-Runtime with intercept queue fix in Docker base image

### DIFF
--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -148,6 +148,43 @@ RUN [ "$ROCM_VERSION" = "7.1.1" ] || (       \
 # This mitigates crashes related to the kernel database.
 ENV MIOPEN_FIND_ENFORCE=SEARCH_DB_UPDATE
 
+# Temporarily include a custom built ROCR-Runtime. This should be removed
+# as soon as https://github.com/ROCm/rocm-systems/pull/2185 lands
+# in a ROCm release that we can install as deb package or with therock.
+# The profiler SDK's intercept queue corrupts AQL packets when they wrap
+# around the ring buffer boundary, causing HSA_STATUS_ERROR_INVALID_PACKET_FORMAT
+# aborts under parallel GPU workloads.
+RUN --mount=type=bind,source=docker/patches/rocr-intercept-queue-fix.patch,target=/tmp/rocr-fix.patch \
+    [ "$ROCM_VERSION" = "7.1.1" ] || (                 \
+    apt-get update && apt-get install -y --no-install-recommends \
+        cmake pkg-config libelf-dev libdrm-dev libnuma-dev rocm-llvm-dev xxd && \
+    git clone --filter=blob:none --no-checkout --depth=1 \
+        --branch rocm-${ROCM_VERSION}                  \
+        https://github.com/ROCm/rocm-systems.git /tmp/rocm-systems && \
+    cd /tmp/rocm-systems &&                            \
+    git sparse-checkout init --cone &&                 \
+    git sparse-checkout set projects/rocr-runtime &&   \
+    git checkout &&                                    \
+    git apply /tmp/rocr-fix.patch &&                   \
+    cd projects/rocr-runtime && mkdir build && cd build && \
+    cmake -DCMAKE_INSTALL_PREFIX=${ROCM_PATH}          \
+          -DCMAKE_PREFIX_PATH=${ROCM_PATH}             \
+          -DCMAKE_BUILD_TYPE=Release                   \
+          -DBUILD_SHARED_LIBS=ON                       \
+          -DCMAKE_C_COMPILER=${ROCM_PATH}/llvm/bin/clang \
+          -DCMAKE_CXX_COMPILER=${ROCM_PATH}/llvm/bin/clang++ .. && \
+    make -j$(nproc) &&                                 \
+    dpkg-divert --no-rename --remove ${ROCM_PATH}/lib/libhsa-runtime64.so.1 ; \
+    dpkg-divert --add --package local                  \
+        --divert ${ROCM_PATH}/lib/libhsa-runtime64.bak.so.1.18.70200 \
+        --rename ${ROCM_PATH}/lib/libhsa-runtime64.so.1.18.70200 && \
+    rm -f ${ROCM_PATH}/lib/libhsa-runtime64.so.1 ${ROCM_PATH}/lib/libhsa-runtime64.so && \
+    cp rocr/lib/libhsa-runtime64.so.1.18.0 ${ROCM_PATH}/lib/libhsa-runtime64.so.1.18.70200 && \
+    ln -sf libhsa-runtime64.so.1.18.70200 ${ROCM_PATH}/lib/libhsa-runtime64.so.1 && \
+    ln -sf libhsa-runtime64.so.1 ${ROCM_PATH}/lib/libhsa-runtime64.so && \
+    cd / && rm -rf /tmp/rocm-systems &&                \
+    apt-get clean && rm -rf /var/lib/apt/lists/* )
+
 ### Set Docker Environment
 ENV PATH="$PATH:/opt/rocm/bin:/opt/rocm/llvm/bin"
 # ENV ln -s "/opt/rocm-${ROCM_RELEASE}/lib/librocblas.so.5" "/opt/rocm-${ROCM_RELEASE}/lib/librocblas.so.4"

--- a/docker/patches/rocr-intercept-queue-fix.patch
+++ b/docker/patches/rocr-intercept-queue-fix.patch
@@ -1,0 +1,79 @@
+diff --git a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h
+index b840ec4a73..b2d4e66627 100644
+--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h
++++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h
+@@ -43,6 +43,7 @@
+ #ifndef HSA_RUNTIME_CORE_INC_INTERCEPT_QUEUE_H_
+ #define HSA_RUNTIME_CORE_INC_INTERCEPT_QUEUE_H_
+ 
++#include <mutex>
+ #include <vector>
+ #include <memory>
+ #include <utility>
+@@ -216,7 +217,7 @@ class InterceptQueue : public QueueProxy, private LocalSignal, public DoorbellSi
+ 
+  private:
+   // Serialize packet interception processing.
+-  KernelMutex lock_;
++  std::mutex lock_;
+ 
+   // Largest processed packet index.
+   uint64_t next_packet_;
+@@ -241,6 +242,9 @@ class InterceptQueue : public QueueProxy, private LocalSignal, public DoorbellSi
+   // Proxy packet buffer
+   SharedArray<AqlPacket, 4096> buffer_;
+ 
++  // Pre-allocated staging buffer for wrap-around cases
++  std::vector<AqlPacket> staging_buffer_;
++
+   // Packet transform callbacks
+   std::vector<std::pair<AMD::callback_t<hsa_amd_queue_intercept_handler>, void*>> interceptors;
+ 
+diff --git a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
+index 2acdffa415..cafd7dc2fc 100644
+--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
++++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
+@@ -127,6 +127,9 @@ InterceptQueue::InterceptQueue(std::unique_ptr<Queue> queue)
+   buffer_ = SharedArray<AqlPacket, 4096>(wrapped->amd_queue_.hsa_queue.size);
+   amd_queue_.hsa_queue.base_address = reinterpret_cast<void*>(&buffer_[0]);
+ 
++  // Pre-allocate staging buffer with queue size
++  staging_buffer_.resize(wrapped->amd_queue_.hsa_queue.size);
++
+   // Fill the ring buffer with invalid packet headers.
+   // Leave packet content uninitialized to help trigger application errors.
+   for (uint32_t pkt_id = 0; pkt_id < wrapped->amd_queue_.hsa_queue.size; ++pkt_id) {
+@@ -337,7 +340,7 @@ void InterceptQueue::StoreRelaxed(hsa_signal_value_t value) {
+     return;
+   }
+ 
+-  ScopedAcquire<KernelMutex> lock(&lock_);
++  std::lock_guard<std::mutex> lock(lock_);
+ 
+   // Submit overflow packets.
+   if (!overflow_.empty()) {
+@@ -398,8 +401,22 @@ void InterceptQueue::StoreRelaxed(hsa_signal_value_t value) {
+     Cursor.interceptor_index = interceptors.size() - 1;
+     Cursor.pkt_index = next_packet_;
+     auto& handler = interceptors[Cursor.interceptor_index];
+-    handler.first(&ring[next_packet_ & mask], packet_count, next_packet_,
+-                                                handler.second, PacketWriter);
++
++    // Check if packets wrap around the ring buffer boundary using unmasked indices.
++    // The interceptor callback expects packets to be contiguous in memory.
++    if ((next_packet_ + packet_count) > ((next_packet_ & ~mask) + amd_queue_.hsa_queue.size)) {
++      // Packets wrap around - use pre-allocated staging buffer
++      for (uint64_t j = 0; j < packet_count; ++j) {
++        staging_buffer_[j] = ring[(next_packet_ + j) & mask];
++      }
++      handler.first(staging_buffer_.data(), packet_count, next_packet_,
++                    handler.second, PacketWriter);
++    } else {
++      // Packets are contiguous in the ring buffer
++      handler.first(&ring[next_packet_ & mask], packet_count, next_packet_,
++                                                 handler.second, PacketWriter);
++    }
++
+     if (IsDeviceMemRingBuf() && needsPcieOrdering()) {
+       // Ensure the packet body is written as header may get reordered when writing over PCIE
+       _mm_sfence();


### PR DESCRIPTION
- Add docker/patches/rocr-intercept-queue-fix.patch with the staging buffer and std::mutex fix from ROCm/rocm-systems#2185
- Add a RUN block to Dockerfile.base-ubu24 that sparse-clones rocm-systems at the matching rocm-${ROCM_VERSION} tag, applies the patch, builds libhsa-runtime64.so with ROCm LLVM clang, and installs it over the packaged version
- The profiler SDK intercept queue corrupts AQL packets when they wrap around the ring buffer boundary, causing HSA_STATUS_ERROR_INVALID_PACKET_FORMAT aborts under parallel GPU workloads (e.g. pytest-xdist with 16 workers on 8 GPUs)
- Remove this block when the fix ships in a ROCm release