### PR TITLE
Update XLA commit hash to 4f77db7 Use BFCAllocator for scratch alloca…

### DIFF
--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -13,7 +13,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 #   1. Find the commit hash you want to pin to (e.g., from rocm-jaxlib-v0.9.1 branch)
 #   2. Update XLA_COMMIT below
 
-XLA_COMMIT = "a0af5e6cf1242ff98743e0392c687a9f8d0d83c3"
+XLA_COMMIT = "4f77db7ac94c8c5c76a296c1e4b157a656333eaf"
 
 def repo():
     git_repository(


### PR DESCRIPTION
…tions needed for MIOpen autotuning

## Motivation

This PR updates the XLA commit hash to 4f77db7  Use BFCAllocator for scratch allocations needed for MIOpen autotuning.
The PR for XLA commit is https://github.com/ROCm/xla/pull/756. It was merged on 03/31/2026.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
