### PR TITLE
Add Bazelisk to CI base container

### DIFF
--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -97,6 +97,12 @@ RUN --mount=type=cache,target=/var/cache/apt \
     rm -rf /tmp/aws /tmp/awscliv2.zip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Install Bazelisk (as `bazel`). It reads .bazelversion from the workspace
+# and automatically downloads + caches the correct Bazel release.
+RUN curl -fsSL https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 \
+        -o /usr/local/bin/bazel && \
+    chmod +x /usr/local/bin/bazel
+
 # Install ROCm:
 RUN --mount=type=bind,source=tools/get_rocm.py,target=get_rocm.py \
     --mount=type=cache,target=/var/cache/apt \


### PR DESCRIPTION
## Summary
- Installs [Bazelisk](https://github.com/bazelbuild/bazelisk) as `bazel` in the base Ubuntu 24.04 CI image (`docker/Dockerfile.base-ubu24`).
- Bazelisk reads `.bazelversion` from the workspace and automatically downloads the correct Bazel release, so builds against jax-ml/jax (currently requiring Bazel 7.7.0) work out of the box without pinning a version in the container.
- Single static binary (~7 MB), no additional apt repos or dependencies needed.

## Test plan
- [ ] Build the base Docker image.