### PR TITLE
Add fix for ROCm version dev builds (#341)

### DIFF
--- a/build/ci_build
+++ b/build/ci_build
@@ -130,11 +130,13 @@ def _docker_image_exists(image):
 
 
 def _construct_manylinux_builder_image_name(rocm_version, rocm_build_job="", rocm_build_num="", therock_path=None):
-    """Create an image name that includes the ROCm ersion, build job, build number, etc"""
+    """Create an image name that includes the ROCm version, build job, build number, etc"""
+    # Docker tags cannot contain '+', so replace it with '.' for compatibility
+    sanitized_version = rocm_version.replace("+", ".")
     return "{base_name}-{rocm_type}-{rocm_version}{rocm_build_job}{rocm_build_num}".format(
         base_name=MANYLINUX_IMAGE_BASE_NAME,
         rocm_type="therock" if therock_path else "rocm",
-        rocm_version=rocm_version,
+        rocm_version=sanitized_version,
         rocm_build_job="-%s" % rocm_build_job if rocm_build_job else "",
         rocm_build_num="-%s" % rocm_build_num if rocm_build_num else "",
     )


### PR DESCRIPTION
## Motivation

The `rocm-jaxlib-v0.9.1` branch fails to build JAX wheels when the ROCm version string contains a `+` character (e.g. `7.13.0.dev0+4d595216f789ae7076f47738b1258133340133ae`). This is because the `+` is directly embedded into the Docker image tag, which only allows `[a-zA-Z0-9_.-]`.

## Technical Details

The `_construct_manylinux_builder_image_name` function in `build/ci_build` passes the raw `rocm_version` into the Docker image tag. The `rocm-jaxlib-v0.9.0` branch already has a fix for this (replacing `+` with `.`), but the fix was not carried over to the `rocm-jaxlib-v0.9.1` branch.
This PR ports the same fix: sanitize the `rocm_version` by replacing `+` with `.` before using it in the Docker tag. Also fixes a minor typo in the docstring (`ersion` → `version`).
Reference: `rocm-jaxlib-v0.9.0` branch, `build/ci_build` lines 133-135.

## Test Plan

- Trigger the TheRock JAX wheel release workflow with `rocm-jaxlib-v0.9.1` in the matrix and a ROCm version containing `+` to verify the Docker build step succeeds.

## Test Result

<!-- Will be updated after CI run completes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
