### PR TITLE
Add zip to CI base container

### DIFF
--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -48,6 +48,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     sqlite3 libsqlite3-dev \
     libbz2-dev \
+    zip \
     # workaround for ROCm missing dep
     # Remove once issue is fixed.
     libdw1t64 && \


### PR DESCRIPTION
## Summary
- Adds the `zip` package to the apt-get install block in `docker/Dockerfile.base-ubu24` so it is available in all CI containers.

## Test plan
- [ ] Verify the base container image builds successfully with the new package.