### PR TITLE
Add TheRock-based CI container using pip wheels

### DIFF
--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -164,9 +164,9 @@ jobs:
           INSTALL_LLVM: ${{ matrix.install-llvm }}
         run: |
           if [ "$INSTALL_LLVM" = "true" ]; then
-            image_tag="jax-dev-therock-ubu24.therock-latest"
+            image_tag="jax-dev-ubu24.therock-latest"
           else
-            image_tag="jax-base-therock-ubu24.therock-latest"
+            image_tag="jax-base-ubu24.therock-latest"
           fi
 
           # Push with commit SHA tag

--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -115,6 +115,134 @@ jobs:
           docker tag "${image_tag}" "${ghcr_image_latest}"
           docker push "${ghcr_image_latest}"
 
+  build-therock-base-images:
+    runs-on: ${{ matrix.runner-label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        install-llvm: [true, false]
+        include:
+          - runner-label: "linux-x86-64-1gpu-amd"
+            therock-index-url: "https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/"
+    steps:
+      - name: Clean up old runs
+        run: |
+          ls -lah
+          docker run --rm -v "./:/rocm-jax" ubuntu \
+            /bin/bash -c "shopt -s dotglob; chown -R $UID /rocm-jax/* || true"
+          rm -rf * || true
+          ls -lah
+          docker system prune -a --filter "until=168h"
+          docker ps --format="{{.RunningFor}} {{.Names}}" | grep hours \
+              | awk -F: '{if($1>12)print$1}' | awk ' {print $4} ' | xargs docker stop || true
+      - name: Print system info
+        run: |
+          whoami
+          printenv
+          df -h
+      - uses: actions/checkout@v4
+      - name: Build TheRock base docker image
+        run: |
+          python3 build/ci_build \
+            build_base_therock_dockers \
+            --filter="therock-ubu24" \
+            --therock-index-url="${{ matrix.therock-index-url }}" \
+            ${{
+              matrix.therock-version
+              && format('--therock-version="{0}"', matrix.therock-version)
+              || ''
+            }} \
+            ${{ matrix.install-llvm && '--install-llvm --llvm-version 18' || '' }}
+      - name: Authenticate to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Push docker images
+        if: github.event_name != 'pull_request'
+        env:
+          INSTALL_LLVM: ${{ matrix.install-llvm }}
+        run: |
+          if [ "$INSTALL_LLVM" = "true" ]; then
+            image_tag="jax-dev-therock-ubu24.therock-latest"
+          else
+            image_tag="jax-base-therock-ubu24.therock-latest"
+          fi
+
+          # Push with commit SHA tag
+          ghcr_image_sha="ghcr.io/rocm/${image_tag}:${GITHUB_SHA}"
+          echo "Image name (SHA): ${ghcr_image_sha}"
+          docker tag "${image_tag}" "${ghcr_image_sha}"
+          docker push "${ghcr_image_sha}"
+
+          # Push with latest tag
+          ghcr_image_latest="ghcr.io/rocm/${image_tag}:latest"
+          echo "Image name (latest): ${ghcr_image_latest}"
+          docker tag "${image_tag}" "${ghcr_image_latest}"
+          docker push "${ghcr_image_latest}"
+
+  build-therock-manylinux-images:
+    runs-on: linux-x86-64-1gpu-amd
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - therock-index-url: >-
+              https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/
+    steps:
+      - name: Clean up old runs
+        run: |
+          ls -lah
+          docker run --rm -v "./:/rocm-jax" ubuntu \
+            /bin/bash -c "shopt -s dotglob; chown -R $UID /rocm-jax/* || true"
+          rm -rf * || true
+          ls -lah
+          docker system prune -a --filter "until=168h"
+          docker ps --format="{{.RunningFor}} {{.Names}}" \
+            | grep hours \
+            | awk -F: '{if($1>12)print$1}' \
+            | awk '{print $4}' \
+            | xargs docker stop || true
+      - name: Print system info
+        run: |
+          whoami
+          printenv
+          df -h
+      - uses: actions/checkout@v4
+      - name: Build TheRock manylinux docker image
+        run: |
+          python3 build/ci_build \
+            build_manylinux_therock_dockers \
+            --therock-index-url="${{ matrix.therock-index-url }}" \
+            ${{
+              matrix.therock-version
+              && format('--therock-version="{0}"',
+                        matrix.therock-version)
+              || ''
+            }}
+      - name: Authenticate to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | docker login ghcr.io \
+              -u ${{ github.actor }} --password-stdin
+      - name: Push docker images
+        if: github.event_name != 'pull_request'
+        run: |
+          image_tag="jax-manylinux_2_28-therock-latest"
+
+          # Push with commit SHA tag
+          ghcr_sha="ghcr.io/rocm/${image_tag}:${GITHUB_SHA}"
+          echo "Image name (SHA): ${ghcr_sha}"
+          docker tag "${image_tag}" "${ghcr_sha}"
+          docker push "${ghcr_sha}"
+
+          # Push with latest tag
+          ghcr_latest="ghcr.io/rocm/${image_tag}:latest"
+          echo "Image name (latest): ${ghcr_latest}"
+          docker tag "${image_tag}" "${ghcr_latest}"
+          docker push "${ghcr_latest}"
+
   build-manylinux-builder-images:
     runs-on: ${{ matrix.runner-label }}
     strategy:

--- a/build/ci_build
+++ b/build/ci_build
@@ -576,6 +576,9 @@ def build_base_therock_dockers(
 
     for dockerfile in dockerfiles:
         _, tag_suffix = dockerfile.split(".", 1)
+        # Strip "-therock" so images match upstream's rocm-tag naming pattern:
+        # jax-base-ubu24.therock-<ver> instead of jax-base-therock-ubu24.therock-<ver>
+        tag_suffix = tag_suffix.replace("-therock", "")
         if add_llvm:
             tag_suffix = tag_suffix.replace("base-", "dev-", 1)
 

--- a/build/ci_build
+++ b/build/ci_build
@@ -556,7 +556,7 @@ def build_base_therock_dockers(
 
     # Derive a tag component from the version pin (e.g. "7.13.0a20260401")
     # or fall back to "latest" when no pin is given.
-    version_tag = therock_version.lstrip("=") if therock_version else "latest"
+    version_tag = therock_version if therock_version else "latest"
     # Sanitise: replace characters that are invalid in Docker tags
     version_tag = version_tag.replace("+", ".").replace(" ", "")
 
@@ -615,7 +615,7 @@ def build_manylinux_therock_dockers(
     no_cache=False,
 ):
     """Build a manylinux image using TheRock pip wheels for release-ready JAX wheels."""
-    version_tag = therock_version.lstrip("=") if therock_version else "latest"
+    version_tag = therock_version if therock_version else "latest"
     version_tag = version_tag.replace("+", ".").replace(" ", "")
 
     constructed_tag = tag or "jax-manylinux_2_28-therock-%s" % version_tag
@@ -870,7 +870,7 @@ def parse_args():
         "--therock-version",
         type=str,
         default="",
-        help="TheRock version specifier for pip (e.g. '==7.13.0a20260401')",
+        help="TheRock version number (e.g. '7.13.0a20260401')",
     )
     btherockp.add_argument(
         "--install-llvm",
@@ -903,7 +903,7 @@ def parse_args():
         "--therock-version",
         type=str,
         default="",
-        help="TheRock version specifier for pip (e.g. '==7.13.0a20260401')",
+        help="TheRock version number (e.g. '7.13.0a20260401')",
     )
     mltherockp.add_argument(
         "--no-cache",

--- a/build/ci_build
+++ b/build/ci_build
@@ -27,7 +27,6 @@ import zipfile
 import json
 import re
 
-
 MANYLINUX_IMAGE_BASE_NAME = "ghcr.io/rocm/jax-manylinux_2_28"
 
 
@@ -538,6 +537,106 @@ def build_base_dockers(
             _tag_and_push_latest(tag)
 
 
+def build_base_therock_dockers(
+    therock_index_url,
+    therock_version="",
+    add_llvm=False,
+    llvm_version=18,
+    tag_base=None,
+    docker_filters=None,
+    push_latest=False,
+    no_cache=False,
+):
+    """Build base Docker images that install ROCm via TheRock pip wheels.
+
+    Unlike the deb/tarball path, these Dockerfiles are self-contained and only
+    need the TheRock pip index URL and an optional version pin.
+    """
+    dockerfiles = _apply_filters(docker_filters, "Dockerfile.base", docker_dir="docker")
+
+    # Derive a tag component from the version pin (e.g. "7.13.0a20260401")
+    # or fall back to "latest" when no pin is given.
+    version_tag = therock_version.lstrip("=") if therock_version else "latest"
+    # Sanitise: replace characters that are invalid in Docker tags
+    version_tag = version_tag.replace("+", ".").replace(" ", "")
+
+    extra_args = [
+        "--build-arg=THEROCK_INDEX_URL=%s" % therock_index_url,
+        "--build-arg=THEROCK_VERSION=%s" % therock_version,
+    ]
+    if no_cache:
+        extra_args.extend(["--no-cache", "--pull"])
+    if add_llvm:
+        extra_args.extend(
+            [
+                "--build-arg=INSTALL_LLVM=%d" % int(add_llvm),
+                "--build-arg=LLVM_VERSION=%s" % llvm_version,
+            ]
+        )
+
+    for dockerfile in dockerfiles:
+        _, tag_suffix = dockerfile.split(".", 1)
+        if add_llvm:
+            tag_suffix = tag_suffix.replace("base-", "dev-", 1)
+
+        tag_suffix = "jax-" + tag_suffix
+
+        if tag_base:
+            tag = "%s.%s.therock-%s" % (tag_base, tag_suffix, version_tag)
+        else:
+            tag = "%s.therock-%s" % (tag_suffix, version_tag)
+
+        print("Building dockerfile=%r to tag=%r" % (dockerfile, tag))
+
+        cmd = [
+            "docker",
+            "build",
+            "-f",
+            dockerfile,
+            "--tag=%s" % tag,
+        ]
+        cmd.extend(extra_args)
+        cmd.append(".")
+
+        subprocess.check_call(cmd)
+
+        if push_latest:
+            _tag_and_push_latest(tag)
+
+
+def build_manylinux_therock_dockers(
+    therock_index_url,
+    therock_version="",
+    tag=None,
+    push_latest=False,
+    no_cache=False,
+):
+    """Build a manylinux image using TheRock pip wheels for release-ready JAX wheels."""
+    version_tag = therock_version.lstrip("=") if therock_version else "latest"
+    version_tag = version_tag.replace("+", ".").replace(" ", "")
+
+    constructed_tag = tag or "jax-manylinux_2_28-therock-%s" % version_tag
+
+    print("Building TheRock manylinux image: %s" % constructed_tag)
+
+    cache_args = ["--no-cache", "--pull"] if no_cache else []
+
+    cmd = [
+        "docker",
+        "build",
+        "-t=%s" % constructed_tag,
+        "--file=docker/manylinux/Dockerfile.jax-manylinux_2_28-therock",
+        "--build-arg=THEROCK_INDEX_URL=%s" % therock_index_url,
+        "--build-arg=THEROCK_VERSION=%s" % therock_version,
+    ]
+    cmd.extend(cache_args)
+    cmd.append(".")
+    subprocess.check_call(cmd)
+
+    if push_latest:
+        _tag_and_push_latest(constructed_tag)
+
+
 def test(image_name, test_cmd=None):
     """Run unit tests like CI would inside a JAX image."""
 
@@ -747,6 +846,68 @@ def parse_args():
         default="18",
     )
 
+    btherockp = subp.add_parser(
+        "build_base_therock_dockers",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    btherockp.add_argument(
+        "--filter",
+        "-f",
+        type=str,
+        help="Comma separated strings to filter Dockerfiles to build. Substring match",
+        default="therock",
+    )
+    btherockp.add_argument(
+        "--therock-index-url",
+        type=str,
+        default="https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/",
+        help="TheRock pip index URL (GPU-family-specific)",
+    )
+    btherockp.add_argument(
+        "--therock-version",
+        type=str,
+        default="",
+        help="TheRock version specifier for pip (e.g. '==7.13.0a20260401')",
+    )
+    btherockp.add_argument(
+        "--install-llvm",
+        help="Enable the installation of LLVM in the containers.",
+        action="store_true",
+    )
+    btherockp.add_argument(
+        "--llvm-version",
+        help="Set the version number of LLVM to be installed.",
+        type=int,
+        default="18",
+    )
+    btherockp.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Build images from scratch without using Docker layer cache",
+    )
+
+    mltherockp = subp.add_parser(
+        "build_manylinux_therock_dockers",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    mltherockp.add_argument(
+        "--therock-index-url",
+        type=str,
+        default="https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/",
+        help="TheRock pip index URL (GPU-family-specific)",
+    )
+    mltherockp.add_argument(
+        "--therock-version",
+        type=str,
+        default="",
+        help="TheRock version specifier for pip (e.g. '==7.13.0a20260401')",
+    )
+    mltherockp.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Build images from scratch without using Docker layer cache",
+    )
+
     testp = subp.add_parser(
         "test", formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
@@ -823,6 +984,25 @@ def main():
             docker_filters=filters,
             add_llvm=args.install_llvm,
             llvm_version=args.llvm_version,
+            no_cache=args.no_cache,
+        )
+
+    elif args.action == "build_base_therock_dockers":
+        filters = args.filter.split(",")
+
+        build_base_therock_dockers(
+            therock_index_url=args.therock_index_url,
+            therock_version=args.therock_version,
+            docker_filters=filters,
+            add_llvm=args.install_llvm,
+            llvm_version=args.llvm_version,
+            no_cache=args.no_cache,
+        )
+
+    elif args.action == "build_manylinux_therock_dockers":
+        build_manylinux_therock_dockers(
+            therock_index_url=args.therock_index_url,
+            therock_version=args.therock_version,
             no_cache=args.no_cache,
         )
 

--- a/docker/Dockerfile.base-therock-ubu24
+++ b/docker/Dockerfile.base-therock-ubu24
@@ -3,7 +3,7 @@ FROM ubuntu:24.04
 ### Container Build Arguments:
 # TheRock nightly index URL (GPU-family-specific).
 ARG THEROCK_INDEX_URL=https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/
-# TheRock version specifier for pip (e.g. "==7.13.0a20260401" or "" for latest).
+# TheRock version number (e.g. "7.13.0a20260401" or "" for latest).
 ARG THEROCK_VERSION=""
 # Enable LLVM install.
 ARG INSTALL_LLVM=0
@@ -49,7 +49,7 @@ RUN apt-get update && \
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     python3 -m pip install --break-system-packages \
         --pre --index-url "${THEROCK_INDEX_URL}" \
-        "rocm[libraries,devel]${THEROCK_VERSION}" && \
+        "rocm[libraries,devel]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
     rocm-sdk init && \
     ln -sfn "$(rocm-sdk path --root)" /opt/rocm
 

--- a/docker/Dockerfile.base-therock-ubu24
+++ b/docker/Dockerfile.base-therock-ubu24
@@ -1,0 +1,117 @@
+FROM ubuntu:24.04
+
+### Container Build Arguments:
+# TheRock nightly index URL (GPU-family-specific).
+ARG THEROCK_INDEX_URL=https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/
+# TheRock version specifier for pip (e.g. "==7.13.0a20260401" or "" for latest).
+ARG THEROCK_VERSION=""
+# Enable LLVM install.
+ARG INSTALL_LLVM=0
+# Version of LLVM to be installed.
+ARG LLVM_VERSION="none"
+
+### Build-time only variables:
+ARG DEBIAN_FRONTEND=noninteractive
+
+### Build Steps:
+
+# Install all Python versions from deadsnakes PPA:
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y \
+        python3.11 python3.11-dev python3.11-venv \
+        python3.12 python3.12-dev python3.12-venv \
+        python3.13 python3.13-dev python3.13-venv \
+        python3.13-nogil \
+        python3.14 python3.14-dev python3.14-venv \
+        python3.14-nogil \
+        python3-pip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set default Python to 3.12:
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 100 && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3.12 100 && \
+    mv /usr/lib/python3.12/EXTERNALLY-MANAGED /usr/lib/python3.12/EXTERNALLY-MANAGED.old
+
+# Install system libraries needed at runtime:
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        sqlite3 libsqlite3-dev \
+        libbz2-dev \
+        zip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install TheRock (ROCm via pip):
+RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
+    python3 -m pip install --break-system-packages \
+        --pre --index-url "${THEROCK_INDEX_URL}" \
+        "rocm[libraries,devel]${THEROCK_VERSION}"
+
+# Install GitHub CLI (gh):
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        gpg && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y gh && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install Google Cloud CLI (gcloud):
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        gnupg \
+        curl && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+        | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+        | tee /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    apt-get update && \
+    apt-get install -y google-cloud-cli && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    gcloud config set auth/disable_credentials True
+
+# Install AWS CLI v2:
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && \
+    apt-get install -y --no-install-recommends curl unzip && \
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip && \
+    unzip -q /tmp/awscliv2.zip -d /tmp && \
+    /tmp/aws/install && \
+    rm -rf /tmp/aws /tmp/awscliv2.zip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install LLVM's clang and lld when enabled:
+RUN --mount=type=cache,target=/var/cache/apt   \
+    [ $INSTALL_LLVM -eq 0 ] || (               \
+    apt update &&                              \
+    apt-get install -y --no-install-recommends \
+        lsb-release                            \
+        software-properties-common             \
+        gnupg                                  \
+        wget &&                                \
+    apt-get purge -y llvm &&                   \
+    cd /tmp &&                                 \
+    wget https://apt.llvm.org/llvm.sh &&       \
+    chmod +x llvm.sh &&                        \
+    ./llvm.sh $LLVM_VERSION clang lld &&       \
+    rm llvm.sh &&                              \
+    apt-get clean && rm -rf /var/lib/apt/lists/* )
+
+LABEL com.amdgpu.therock_index_url="$THEROCK_INDEX_URL" \
+      com.amdgpu.therock_version="$THEROCK_VERSION" \
+      com.amdgpu.python_versions="3.11,3.12,3.13,3.13-nogil,3.14,3.14-nogil" \
+      com.amdgpu.install_llvm="$INSTALL_LLVM" \
+      com.amdgpu.llvm_version="$LLVM_VERSION"

--- a/docker/Dockerfile.base-therock-ubu24
+++ b/docker/Dockerfile.base-therock-ubu24
@@ -93,6 +93,12 @@ RUN --mount=type=cache,target=/var/cache/apt \
     rm -rf /tmp/aws /tmp/awscliv2.zip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Install Bazelisk (as `bazel`). It reads .bazelversion from the workspace
+# and automatically downloads + caches the correct Bazel release.
+RUN curl -fsSL https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 \
+        -o /usr/local/bin/bazel && \
+    chmod +x /usr/local/bin/bazel
+
 # Install LLVM's clang and lld when enabled:
 RUN --mount=type=cache,target=/var/cache/apt   \
     [ $INSTALL_LLVM -eq 0 ] || (               \

--- a/docker/Dockerfile.base-therock-ubu24
+++ b/docker/Dockerfile.base-therock-ubu24
@@ -44,11 +44,18 @@ RUN apt-get update && \
         zip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install TheRock (ROCm via pip):
+# Install TheRock (ROCm via pip), initialize the SDK, and create a
+# conventional /opt/rocm symlink so ENV directives use a known path.
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     python3 -m pip install --break-system-packages \
         --pre --index-url "${THEROCK_INDEX_URL}" \
-        "rocm[libraries,devel]${THEROCK_VERSION}"
+        "rocm[libraries,devel]${THEROCK_VERSION}" && \
+    rocm-sdk init && \
+    ln -sfn "$(rocm-sdk path --root)" /opt/rocm
+
+ENV ROCM_HOME=/opt/rocm
+ENV PATH="/opt/rocm/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rocm/lib"
 
 # Install GitHub CLI (gh):
 RUN --mount=type=cache,target=/var/cache/apt \

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -3,10 +3,8 @@ FROM quay.io/pypa/manylinux_2_28_x86_64
 ### Container Build Arguments:
 # TheRock nightly index URL (GPU-family-specific).
 ARG THEROCK_INDEX_URL=https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/
-# TheRock version specifier for pip (e.g. "==7.13.0a20260401" or "" for latest).
+# TheRock version number (e.g. "7.13.0a20260401" or "" for latest).
 ARG THEROCK_VERSION=""
-
-ENV GPU_DEVICE_TARGETS="gfx906 gfx908 gfx90a gfx9-4-generic gfx10-3-generic gfx11-generic gfx12-generic"
 
 # Install patchelf and headers for numactl
 RUN --mount=type=cache,target=/var/cache/dnf \
@@ -18,7 +16,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     /opt/python/cp312-cp312/bin/python3 -m pip install \
         --pre --index-url "${THEROCK_INDEX_URL}" \
-        "rocm[libraries,devel]${THEROCK_VERSION}" && \
+        "rocm[libraries,devel]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
     ln -sf /opt/python/cp312-cp312/bin/rocm-sdk /usr/local/bin/rocm-sdk && \
     rocm-sdk init && \
     ln -sfn "$(rocm-sdk path --root)" /opt/rocm

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -13,10 +13,12 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y patchelf numactl-devel vim-common
 
 # Install TheRock (ROCm via pip):
+# manylinux_2_28's system python3 (3.6) lacks pip; use a /opt/python/ build.
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
-    python3 -m pip install \
+    /opt/python/cp312-cp312/bin/python3 -m pip install \
         --pre --index-url "${THEROCK_INDEX_URL}" \
-        "rocm[libraries,devel]${THEROCK_VERSION}"
+        "rocm[libraries,devel]${THEROCK_VERSION}" && \
+    ln -sf /opt/python/cp312-cp312/bin/rocm-sdk /usr/local/bin/rocm-sdk
 
 # Initialize TheRock SDK (expand devel tarball):
 RUN rocm-sdk init

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -1,40 +1,55 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
+### Container Build Arguments:
+# TheRock nightly index URL (GPU-family-specific).
+ARG THEROCK_INDEX_URL=https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/
+# TheRock version specifier for pip (e.g. "==7.13.0a20260401" or "" for latest).
+ARG THEROCK_VERSION=""
 
-ARG ROCM_VERSION
-ARG THEROCK_PATH
 ENV GPU_DEVICE_TARGETS="gfx906 gfx908 gfx90a gfx9-4-generic gfx10-3-generic gfx11-generic gfx12-generic"
 
 # Install patchelf and headers for numactl
 RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y patchelf numactl-devel vim-common
 
-# Install ROCm
-RUN --mount=type=cache,target=/var/cache/dnf \
-    --mount=type=bind,source=./tools/get_rocm.py,target=get_rocm.py \
-    python3 get_rocm.py --rocm-version=$ROCM_VERSION --therock-path=$THEROCK_PATH
-ENV PATH="$PATH:/opt/rocm/bin:/opt/rocm/llvm/bin"
-RUN printf '%s\n' > /opt/rocm/bin/target.lst ${GPU_DEVICE_TARGETS}
+# Install TheRock (ROCm via pip):
+RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
+    python3 -m pip install \
+        --pre --index-url "${THEROCK_INDEX_URL}" \
+        "rocm[libraries,devel]${THEROCK_VERSION}"
 
-# Install LLVM 18 and dependencies.
+# Initialize TheRock SDK (expand devel tarball):
+RUN rocm-sdk init
+
+# Install LLVM 18 from source (manylinux has no apt):
 RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y wget && dnf clean all
-RUN mkdir /tmp/llvm-project && wget -qO - https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-18.1.8.tar.gz | tar -xz -C /tmp/llvm-project --strip-components 1 && \
-    mkdir /tmp/llvm-project/build && cd /tmp/llvm-project/build && cmake -DLLVM_ENABLE_PROJECTS='clang;lld' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-18/ ../llvm && \
-    make -j$(nproc) && make -j$(nproc) install && rm -rf /tmp/llvm-project
+RUN mkdir /tmp/llvm-project && \
+    wget -qO - https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-18.1.8.tar.gz \
+        | tar -xz -C /tmp/llvm-project --strip-components 1 && \
+    mkdir /tmp/llvm-project/build && \
+    cd /tmp/llvm-project/build && \
+    cmake -DLLVM_ENABLE_PROJECTS='clang;lld' \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-18/ \
+          ../llvm && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    rm -rf /tmp/llvm-project
 
-# Copy in our clang configuiration file
+# Copy in our clang configuration file
 COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang++.cfg
 COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang.cfg
-COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang++.cfg
-COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang.cfg
 
 # Install AWS CLI v2
 RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y curl unzip && \
-    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip && \
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" \
+        -o /tmp/awscliv2.zip && \
     unzip -q /tmp/awscliv2.zip -d /tmp && \
     /tmp/aws/install && \
     rm -rf /tmp/aws /tmp/awscliv2.zip && \
     dnf clean all
 
+LABEL com.amdgpu.therock_index_url="$THEROCK_INDEX_URL" \
+      com.amdgpu.therock_version="$THEROCK_VERSION"

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -12,16 +12,20 @@ ENV GPU_DEVICE_TARGETS="gfx906 gfx908 gfx90a gfx9-4-generic gfx10-3-generic gfx1
 RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y patchelf numactl-devel vim-common
 
-# Install TheRock (ROCm via pip):
+# Install TheRock (ROCm via pip), initialize the SDK, and create a
+# conventional /opt/rocm symlink so ENV directives use a known path.
 # manylinux_2_28's system python3 (3.6) lacks pip; use a /opt/python/ build.
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     /opt/python/cp312-cp312/bin/python3 -m pip install \
         --pre --index-url "${THEROCK_INDEX_URL}" \
         "rocm[libraries,devel]${THEROCK_VERSION}" && \
-    ln -sf /opt/python/cp312-cp312/bin/rocm-sdk /usr/local/bin/rocm-sdk
+    ln -sf /opt/python/cp312-cp312/bin/rocm-sdk /usr/local/bin/rocm-sdk && \
+    rocm-sdk init && \
+    ln -sfn "$(rocm-sdk path --root)" /opt/rocm
 
-# Initialize TheRock SDK (expand devel tarball):
-RUN rocm-sdk init
+ENV ROCM_HOME=/opt/rocm
+ENV PATH="/opt/rocm/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rocm/lib"
 
 # Install LLVM 18 from source (manylinux has no apt):
 RUN --mount=type=cache,target=/var/cache/dnf \


### PR DESCRIPTION
## Summary

- Add `docker/Dockerfile.base-therock-ubu24` — a streamlined base image that installs ROCm via [TheRock](https://github.com/ROCm/TheRock) nightly pip wheels (`pip install --pre --index-url ... "rocm[libraries,devel]"`). The image includes Python 3.11–3.14 (with nogil variants), CLI tools (gh, gcloud, aws), and an optional LLVM toggle. No `ENV` variables are set — `PATH`, `ROCM_PATH`, and `GPU_DEVICE_TARGETS` are left to the CI workflow.
- Add `build_base_therock_dockers` subcommand to `build/ci_build` to drive the build with `--build-arg` for the TheRock index URL, version pin, and LLVM toggle.
- Add `build-therock-base-images` job to `.github/workflows/build-base-docker.yml` that builds both base and dev (with LLVM 18) variants for `gfx950-dcgpu`, tagged and pushed to GHCR.
- Apply `black` formatting fixes to `build/ci_build`.