### PR TITLE
Add unversioned Python in manylinux dockerfile

### DIFF
--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
@@ -38,3 +38,6 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     rm -rf /tmp/aws /tmp/awscliv2.zip && \
     dnf clean all
 
+# The manylinux base image provides python3 but not unversioned 'python'.
+# CI scripts currently require this so we symlink Python to Python3.
+RUN ln -s /usr/bin/python3 /usr/local/bin/python


### PR DESCRIPTION
## Motivation
The CI scripts for JAX currently require an unversioned Python in order to execute build orchestration. Python has been symlinked to Python3 in order to satisfy this dependency.

## Changes
The change is a single symlink in file: `docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm`