### PR TITLE
Adjust unversioned Python to symlink to Python 3.11.

### DIFF
--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
@@ -40,4 +40,4 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 
 # The manylinux base image provides python3 but not unversioned 'python'.
 # CI scripts currently require this so we symlink Python to Python3.
-RUN ln -s /usr/bin/python3 /usr/local/bin/python
+RUN ln -s /usr/bin/python3.11 /usr/local/bin/python


### PR DESCRIPTION
## Motivation
Originally, symlinking Python to Python3 resulted in a symlink to Python 3.6. In order to use a more recent version, we specify Python 3.11. This will satisfy some of the version dependencies needed in the JAX CI scripts.

## Changes
The only change is to file: `docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm`. The version of Python 3 that is being symlinked is specified as Python 3.11 which was already on the manylinux image.