### PR TITLE
Add optional gpu-arch option to wheel build pipeline

### DIFF
--- a/build/ci_build
+++ b/build/ci_build
@@ -188,6 +188,7 @@ def dist_wheels(
     builder_image=None,
     wheel_post_release=None,
     include_rocm_version_extra=True,
+    gpu_arch="",
 ):
     jax_plugin_dir = "jax_rocm_plugin"
 
@@ -235,6 +236,9 @@ def dist_wheels(
 
     if not include_rocm_version_extra:
         cmd.append("--no-rocm-version-extra")
+
+    if gpu_arch:
+        cmd.append("--gpu-arch=%s" % gpu_arch)
 
     cmd.append("dist_wheels")
     subprocess.check_call(cmd, cwd=jax_plugin_dir)
@@ -640,6 +644,13 @@ def parse_args():
         action="store_true",
         help="Do not append local '+rocm...' version tag to plugin/PJRT wheels",
     )
+    p.add_argument(
+        "--gpu-arch",
+        type=str,
+        default="",
+        help="GPU architecture for arch-specific wheels (e.g. gfx950). "
+        "When set, builds only for this arch and embeds it in wheel names.",
+    )
 
     subp = p.add_subparsers(dest="action", required=True)
 
@@ -742,6 +753,7 @@ def main():
             builder_image=args.builder_image,
             wheel_post_release=args.wheel_post_release,
             include_rocm_version_extra=not args.no_rocm_version_extra,
+            gpu_arch=args.gpu_arch,
         )
 
     if args.action == "build_dockers":

--- a/jax_rocm_plugin/build/build.py
+++ b/jax_rocm_plugin/build/build.py
@@ -245,6 +245,14 @@ def add_artifact_subcommand_arguments(parser: argparse.ArgumentParser):
     )
 
     rocm_group.add_argument(
+        "--gpu_arch",
+        type=str,
+        default="",
+        help="GPU architecture for arch-specific wheels (e.g. gfx950). "
+        "When set, overrides --rocm_amdgpu_targets to build for this arch only.",
+    )
+
+    rocm_group.add_argument(
         "--rocm_path",
         type=str,
         default="",
@@ -621,6 +629,12 @@ async def main():
             wheel_build_command_base.append(
                 f'--action_env=ROCM_PATH="{args.rocm_path}"'
             )
+        if args.gpu_arch and args.gpu_arch != "all":
+            logging.info(
+                "GPU arch set: overriding rocm_amdgpu_targets to %s", args.gpu_arch
+            )
+            args.rocm_amdgpu_targets = args.gpu_arch
+
         if args.rocm_amdgpu_targets:
             rocm_version_str = get_rocm_version(args.rocm_path)
             rocm_version = (
@@ -716,6 +730,8 @@ async def main():
             if "rocm" in wheel:
                 wheel_build_command.append("--enable-rocm=True")
                 wheel_build_command.append(f"--platform_version={args.rocm_version}")
+                if args.gpu_arch:
+                    wheel_build_command.append(f"--gpu_arch={args.gpu_arch}")
 
             wheel_build_command.append(f"--rocm_jax_git_hash={git_hash}")
 

--- a/jax_rocm_plugin/build/rocm/ci_build
+++ b/jax_rocm_plugin/build/rocm/ci_build
@@ -51,6 +51,7 @@ def dist_wheels(
     builder_image,
     wheel_post_release=None,
     include_rocm_version_extra=True,
+    gpu_arch="",
 ):
     if xla_path:
         xla_path = os.path.abspath(xla_path)
@@ -85,6 +86,9 @@ def dist_wheels(
 
     if wheel_post_release is not None:
         bw_cmd.extend(["--wheel-post-release", str(wheel_post_release)])
+
+    if gpu_arch:
+        bw_cmd.extend(["--gpu-arch", gpu_arch])
 
     bw_cmd.append(container_plugin_path)
     container_cmd = " ".join(bw_cmd)
@@ -234,6 +238,12 @@ def parse_args():
         action="store_true",
         help="Do not append local '+rocm...' version tag to plugin/PJRT wheels",
     )
+    p.add_argument(
+        "--gpu-arch",
+        type=str,
+        default="",
+        help="GPU architecture for arch-specific wheels (e.g. gfx950).",
+    )
 
     subp = p.add_subparsers(dest="action", required=True)
 
@@ -259,6 +269,7 @@ def main():
             args.builder_image,
             args.wheel_post_release,
             not args.no_rocm_version_extra,
+            gpu_arch=args.gpu_arch,
         )
 
     elif args.action == "test":

--- a/jax_rocm_plugin/build/rocm/tools/build_wheels.py
+++ b/jax_rocm_plugin/build/rocm/tools/build_wheels.py
@@ -42,6 +42,8 @@ GPU_DEVICE_TARGETS = (
     "gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1200 gfx1201"
 )
 
+ALL_GPU_ARCHS = GPU_DEVICE_TARGETS.split()
+
 
 # pylint: disable=R0801
 # This function reads the version file from inside a ROCm installation
@@ -148,12 +150,14 @@ def build_plugin_wheel(
     compiler="gcc",
     wheels="jax-rocm-plugin,jax-rocm-pjrt",
     wheel_post_release=None,
+    gpu_arch="",
 ):
     """Build ROCm plugin and/or PJRT wheels via jax_rocm_plugin/build/build.py.
 
     Args:
         wheels: Comma-separated list of wheels to build. Valid options are
                 'jax-rocm-plugin', 'jax-rocm-pjrt', or both.
+        gpu_arch: GPU architecture for arch-specific wheels (e.g. 'gfx950').
     """
     use_clang = compiler == "clang"
 
@@ -191,6 +195,9 @@ def build_plugin_wheel(
             cmd.append("--clang_path=%s" % clang_path)
         else:
             raise RuntimeError("Clang binary not found in /usr/lib/llvm-*")
+
+    if gpu_arch:
+        cmd.append("--gpu_arch=%s" % gpu_arch)
 
     if xla_path:
         cmd.append("--bazel_options=--override_repository=xla=%s" % xla_path)
@@ -429,6 +436,13 @@ def parse_args():
         default=None,
         help="Optional post-release suffix number to append as .postX",
     )
+    p.add_argument(
+        "--gpu-arch",
+        type=str,
+        default="",
+        help="GPU architecture for arch-specific wheels (e.g. gfx950). "
+        "When set, builds only for this arch and embeds it in wheel names.",
+    )
 
     p.add_argument(
         "plugin_path", help="Directory where JAX ROCm plugin source is located"
@@ -468,6 +482,8 @@ def main():
             rocm_path = "/opt/rocm"
         rocm_version = get_rocm_version(rocm_path)
 
+    gpu_arch = args.gpu_arch
+
     print("ROCM_PATH=%s" % rocm_path)
     print("ROCM_VERSION=%s" % rocm_version)
     print("PYTHON_VERSIONS=%r" % python_versions)
@@ -475,11 +491,16 @@ def main():
     print("JAX_PATH=%s" % args.jax_path)
     print("XLA_PATH=%s" % args.xla_path)
     print("COMPILER=%s" % args.compiler)
+    print("GPU_ARCH=%s" % (gpu_arch or "(fat)"))
     print("OUTPUT_DIR=%s" % manylinux_output_dir)
 
-    update_rocm_targets(rocm_path, GPU_DEVICE_TARGETS)
+    if gpu_arch == "all":
+        arch_list = ALL_GPU_ARCHS
+    elif gpu_arch:
+        arch_list = [gpu_arch]
+    else:
+        arch_list = [""]
 
-    # Build plugin + PJRT wheels.
     full_output_path = os.path.join(args.plugin_path, manylinux_output_dir)
     os.makedirs(full_output_path, exist_ok=True)
 
@@ -489,50 +510,61 @@ def main():
         print("Removing wheel=%r" % whl)
         os.remove(whl)
 
-    # Build PJRT wheel once (it's Python version agnostic).
-    print("Building PJRT wheel (Python version agnostic)...")
-    build_plugin_wheel(
-        args.plugin_path,
-        rocm_path,
-        rocm_version,
-        python_versions[0],  # Use first Python version for build environment
-        full_output_path,
-        args.xla_path,
-        args.rbe,
-        args.compiler,
-        wheels="jax-rocm-pjrt",
-        wheel_post_release=args.wheel_post_release,
-    )
-    # Fix PJRT wheel.
-    wheel_paths = find_wheels(full_output_path)
-    for wheel_path in wheel_paths:
-        if "pjrt" in os.path.basename(wheel_path).lower():
-            fix_wheel(wheel_path, args.plugin_path)
+    fixed_wheels = set()
 
-    # Build plugin wheel for each Python version.
-    for py in python_versions:
-        print("Building plugin wheel for Python %s..." % py)
+    for arch in arch_list:
+        device_targets = arch if arch else GPU_DEVICE_TARGETS
+        arch_label = arch or "all-archs"
+        print("\n===== Building wheels for %s =====" % arch_label)
+
+        update_rocm_targets(rocm_path, device_targets)
+
+        # Build PJRT wheel once per arch (it's Python version agnostic).
+        print("Building PJRT wheel for %s..." % arch_label)
         build_plugin_wheel(
             args.plugin_path,
             rocm_path,
             rocm_version,
-            py,
+            python_versions[0],
             full_output_path,
             args.xla_path,
             args.rbe,
             args.compiler,
-            wheels="jax-rocm-plugin",
+            wheels="jax-rocm-pjrt",
             wheel_post_release=args.wheel_post_release,
+            gpu_arch=arch,
         )
-        # Fix plugin wheels for this Python version.
-        wheel_paths = find_wheels(full_output_path)
-        for wheel_path in wheel_paths:
-            base = os.path.basename(wheel_path)
-            # Only fix plugin wheels, skip already-fixed PJRT wheel.
-            if "plugin" in base.lower():
+        for wheel_path in find_wheels(full_output_path):
+            if (
+                wheel_path not in fixed_wheels
+                and "pjrt" in os.path.basename(wheel_path).lower()
+            ):
                 fix_wheel(wheel_path, args.plugin_path)
+                fixed_wheels.add(wheel_path)
 
-    # Copy plugin + PJRT wheels to wheelhouse.
+        # Build plugin wheel for each Python version.
+        for py in python_versions:
+            print("Building plugin wheel for %s Python %s..." % (arch_label, py))
+            build_plugin_wheel(
+                args.plugin_path,
+                rocm_path,
+                rocm_version,
+                py,
+                full_output_path,
+                args.xla_path,
+                args.rbe,
+                args.compiler,
+                wheels="jax-rocm-plugin",
+                wheel_post_release=args.wheel_post_release,
+                gpu_arch=arch,
+            )
+            for wheel_path in find_wheels(full_output_path):
+                base = os.path.basename(wheel_path)
+                if wheel_path not in fixed_wheels and "plugin" in base.lower():
+                    fix_wheel(wheel_path, args.plugin_path)
+                    fixed_wheels.add(wheel_path)
+
+    # Copy all wheels to wheelhouse.
     wheel_paths = find_wheels(full_output_path)
     for whl in wheel_paths:
         LOG.info("Copying %s into %s", whl, wheelhouse_dir)

--- a/jax_rocm_plugin/jax_plugins/rocm/plugin_setup.py
+++ b/jax_rocm_plugin/jax_plugins/rocm/plugin_setup.py
@@ -22,8 +22,15 @@ from setuptools.dist import Distribution
 
 __version__ = None
 rocm_version = 0  # placeholder  # pylint: disable=invalid-name
-project_name = f"jax-rocm{rocm_version}-plugin"  # pylint: disable=invalid-name
-package_name = f"jax_rocm{rocm_version}_plugin"  # pylint: disable=invalid-name
+gpu_arch = ""  # placeholder  # pylint: disable=invalid-name
+_arch_suffix = f"-{gpu_arch}" if gpu_arch else ""  # pylint: disable=invalid-name
+_arch_uscore = f"_{gpu_arch}" if gpu_arch else ""  # pylint: disable=invalid-name
+project_name = (  # pylint: disable=invalid-name
+    f"jax-rocm{rocm_version}-plugin{_arch_suffix}"
+)
+package_name = (  # pylint: disable=invalid-name
+    f"jax_rocm{rocm_version}_plugin{_arch_uscore}"
+)
 
 # Extract ROCm version from the `ROCM_PATH` environment variable.
 default_rocm_path = "/opt/rocm"  # pylint: disable=invalid-name
@@ -97,7 +104,7 @@ setup(
     packages=[package_name],
     python_requires=">=3.11",
     install_requires=[
-        f"jax-rocm{rocm_version}-pjrt=="
+        f"jax-rocm{rocm_version}-pjrt{_arch_suffix}=="
         f"{_version_module._version}.*"  # pylint: disable=protected-access
     ],
     url="https://github.com/ROCm/rocm-jax",

--- a/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
@@ -75,6 +75,12 @@ parser.add_argument(
 parser.add_argument(
     "--enable-rocm", default=False, help="Should we build with ROCM enabled?"
 )
+parser.add_argument(
+    "--gpu_arch",
+    type=str,
+    default="",
+    help="GPU architecture suffix for arch-specific wheels (e.g. gfx950).",
+)
 
 parser.add_argument(
     "--xla-commit",
@@ -162,10 +168,13 @@ def get_jax_commit_hash():
     return args.jax_commit
 
 
-def prepare_wheel_rocm(wheel_sources_path: pathlib.Path, *, cpu, rocm_version, srcs):
+def prepare_wheel_rocm(
+    wheel_sources_path: pathlib.Path, *, cpu, rocm_version, srcs, gpu_arch=""
+):
     # pylint: disable=too-many-locals
     """Assembles a source tree for the rocm kernel wheel in `sources_path`."""
-    plugin_dir = wheel_sources_path / f"jax_rocm{rocm_version}_plugin"
+    arch_uscore = f"_{gpu_arch}" if gpu_arch else ""
+    plugin_dir = wheel_sources_path / f"jax_rocm{rocm_version}_plugin{arch_uscore}"
     os.makedirs(plugin_dir, exist_ok=True)
 
     # Copy config files: from --srcs if provided, else from runfiles
@@ -189,6 +198,7 @@ def prepare_wheel_rocm(wheel_sources_path: pathlib.Path, *, cpu, rocm_version, s
         shutil.copy(rloc("pjrt/python/version.py"), plugin_dir)
 
     build_utils.update_setup_with_rocm_version(wheel_sources_path, rocm_version)
+    build_utils.update_setup_with_gpu_arch(wheel_sources_path, gpu_arch)
     write_setup_cfg(wheel_sources_path, cpu)
     xla_commit_hash = get_xla_commit_hash()
     jax_commit_hash = get_jax_commit_hash()
@@ -259,8 +269,10 @@ try:
         cpu=args.cpu,
         rocm_version=args.platform_version,
         srcs=args.srcs,
+        gpu_arch=args.gpu_arch,
     )
-    package_name = f"jax rocm{args.platform_version} plugin"
+    arch_label = f" {args.gpu_arch}" if args.gpu_arch else ""
+    package_name = f"jax rocm{args.platform_version} plugin{arch_label}"
     if args.editable:
         build_utils.build_editable(sources_path, args.output_path, package_name)
     else:

--- a/jax_rocm_plugin/jaxlib_ext/tools/build_utils.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_utils.py
@@ -202,6 +202,20 @@ def update_setup_with_rocm_version(file_dir: pathlib.Path, rocm_version: str):
         f.write(content)
 
 
+def update_setup_with_gpu_arch(file_dir: pathlib.Path, gpu_arch: str):
+    """Update setup.py with the specified GPU architecture suffix."""
+    if not gpu_arch:
+        return
+    src_file = file_dir / "setup.py"
+    with open(src_file, encoding="utf-8") as f:
+        content = f.read()
+    content = content.replace(
+        'gpu_arch = ""  # placeholder', f'gpu_arch = "{gpu_arch}"'
+    )
+    with open(src_file, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
 def write_commit_info(plugin_dir, xla_commit, jax_commit, rocm_jax_commit):
     """Write commit hash information into commit_info.py inside `plugin_dir`."""
     os.makedirs(plugin_dir, exist_ok=True)

--- a/jax_rocm_plugin/pjrt/python/setup.py
+++ b/jax_rocm_plugin/pjrt/python/setup.py
@@ -21,8 +21,15 @@ from setuptools import setup, find_namespace_packages
 
 __version__ = None
 rocm_version = 0  # placeholder  # pylint: disable=invalid-name
-project_name = f"jax-rocm{rocm_version}-pjrt"  # pylint: disable=invalid-name
-package_name = f"jax_plugins.xla_rocm{rocm_version}"  # pylint: disable=invalid-name
+gpu_arch = ""  # placeholder  # pylint: disable=invalid-name
+_arch_suffix = f"-{gpu_arch}" if gpu_arch else ""  # pylint: disable=invalid-name
+_arch_uscore = f"_{gpu_arch}" if gpu_arch else ""  # pylint: disable=invalid-name
+project_name = (  # pylint: disable=invalid-name
+    f"jax-rocm{rocm_version}-pjrt{_arch_suffix}"
+)
+package_name = (  # pylint: disable=invalid-name
+    f"jax_plugins.xla_rocm{rocm_version}{_arch_uscore}"
+)
 
 # Extract ROCm version from the `ROCM_PATH` environment variable.
 default_rocm_path = "/opt/rocm"  # pylint: disable=invalid-name
@@ -61,7 +68,9 @@ def load_version_module(pkg_path):
     return module
 
 
-_version_module = load_version_module(f"jax_plugins/xla_rocm{rocm_version}")
+_version_module = load_version_module(
+    f"jax_plugins/xla_rocm{rocm_version}{_arch_uscore}"
+)
 __version__ = (
     _version_module._get_version_for_build()  # pylint: disable=protected-access
 )
@@ -98,7 +107,7 @@ setup(
     zip_safe=False,
     entry_points={
         "jax_plugins": [
-            f"xla_rocm{rocm_version} = {package_name}",
+            f"xla_rocm{rocm_version}{_arch_uscore} = {package_name}",
         ],
     },
 )

--- a/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
+++ b/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
@@ -77,6 +77,12 @@ parser.add_argument(
     "--enable-rocm", default=False, help="Should we build with ROCM enabled?"
 )
 parser.add_argument(
+    "--gpu_arch",
+    type=str,
+    default="",
+    help="GPU architecture suffix for arch-specific wheels (e.g. gfx950).",
+)
+parser.add_argument(
     "--xla-commit",
     default="",
     help="rocm/xla Git hash. Empty if unknown.",
@@ -159,10 +165,13 @@ def get_jax_commit_hash():
 
 
 def prepare_rocm_plugin_wheel(
-    wheel_sources_path: pathlib.Path, *, cpu, rocm_version, srcs
+    wheel_sources_path: pathlib.Path, *, cpu, rocm_version, srcs, gpu_arch=""
 ):
     """Assembles a source tree for the ROCm wheel in `sources_path`."""
-    plugin_dir = wheel_sources_path / "jax_plugins" / f"xla_rocm{rocm_version}"
+    arch_uscore = f"_{gpu_arch}" if gpu_arch else ""
+    plugin_dir = (
+        wheel_sources_path / "jax_plugins" / f"xla_rocm{rocm_version}{arch_uscore}"
+    )
     os.makedirs(plugin_dir, exist_ok=True)
 
     if srcs:
@@ -186,6 +195,7 @@ def prepare_rocm_plugin_wheel(
         )
 
     build_utils.update_setup_with_rocm_version(wheel_sources_path, rocm_version)
+    build_utils.update_setup_with_gpu_arch(wheel_sources_path, gpu_arch)
     write_setup_cfg(wheel_sources_path, cpu)
     xla_commit_hash = get_xla_commit_hash()
     jax_commit_hash = get_jax_commit_hash()
@@ -238,8 +248,10 @@ try:
             cpu=args.cpu,
             rocm_version=args.platform_version,
             srcs=args.srcs,
+            gpu_arch=args.gpu_arch,
         )
-        package_name = "jax rocm plugin"
+        arch_label = f" {args.gpu_arch}" if args.gpu_arch else ""
+        package_name = f"jax rocm plugin{arch_label}"
     else:
         raise ValueError("Unsupported backend. Choose 'rocm'.")
 

--- a/jax_rocm_plugin/pjrt/tools/build_utils.py
+++ b/jax_rocm_plugin/pjrt/tools/build_utils.py
@@ -201,6 +201,20 @@ def update_setup_with_rocm_version(file_dir: pathlib.Path, rocm_version: str):
         f.write(content)
 
 
+def update_setup_with_gpu_arch(file_dir: pathlib.Path, gpu_arch: str):
+    """Update setup.py with the specified GPU architecture suffix."""
+    if not gpu_arch:
+        return
+    src_file = file_dir / "setup.py"
+    with open(src_file, encoding="utf-8") as f:
+        content = f.read()
+    content = content.replace(
+        'gpu_arch = ""  # placeholder', f'gpu_arch = "{gpu_arch}"'
+    )
+    with open(src_file, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
 def write_commit_info(plugin_dir, xla_commit, jax_commit, rocm_jax_commit):
     """Write commit hash information into commit_info.py inside `plugin_dir`."""
     os.makedirs(plugin_dir, exist_ok=True)


### PR DESCRIPTION
## Motivation

Add optional --gpu-arch flag for architecture-specific ROCm wheel builds

## Technical Details

- Adds --gpu-arch option threaded through the entire build pipeline (build.py, CI scripts, wheel builders, and setup scripts)
- Enables producing architecture-specific wheels (e.g. jax-rocm7-plugin-gfx950) alongside existing fat multi-arch wheels
- When set, overrides --rocm_amdgpu_targets to build for a single arch and embeds the arch into wheel/package names
- When omitted, behavior is completely unchanged (backward-compatible)
- Supports --gpu-arch=all to build a separate wheel per known architecture in one invocation
- Setup scripts derive hyphenated suffix for PyPI names (-gfx950) and underscored suffix for Python packages (_gfx950)
- Plugin install_requires correctly chains to the matching arch-specific PJRT wheel

## Test Plan

Built and tested wheels with this flag. 

## Test Result

Wheels functional.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
