### PR TITLE
Add jax source to PYTHONPATH for test imports

### DIFF
--- a/jax_rocm_plugin/build/rocm/run_single_gpu.py
+++ b/jax_rocm_plugin/build/rocm/run_single_gpu.py
@@ -41,6 +41,9 @@ from collections import defaultdict
 # Add the configuration directory to Python path
 sys.path.insert(0, "jax_rocm_plugin/build/rocm")
 
+# Use the jax source tree so test-only modules (e.g. pallas_test_util) are importable.
+os.environ["PYTHONPATH"] = os.path.abspath("jax") + os.pathsep + os.environ.get("PYTHONPATH", "")
+
 GPU_LOCK = threading.Lock()
 LAST_CODE = 0
 BASE_DIR = "./logs"


### PR DESCRIPTION
## Description
Prepends the jax source directory to PYTHONPATH so pytest subprocesses import test-only modules (pallas_test_util, pipelining/, mosaic/gpu/examples/) from the source tree instead of the installed wheel, which doesn't include them. Matches upstream jax-ml/jax CI behavior.

## Test plan
[x] Ran pytest --collect-only in Docker -- 35,033 tests collected, zero ImportErrors (was 183 errors before)
[x] Ran full run_single_gpu.py -c in Docker with 8 GPUs -- all 12 previously failing test modules (pallas, mosaic, pipelining) collect and skip correctly