### PR TITLE
Update XLA hash to 83511bb (04/15/26)

### DIFF
--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -13,7 +13,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 #   1. Find the commit hash you want to pin to (e.g., from rocm-jaxlib-v0.9.1 branch)
 #   2. Update XLA_COMMIT below
 
-XLA_COMMIT = "7dc954d7b1312eae25689e9cbfebc744f9a31206"
+XLA_COMMIT = "83511bbb674157d2db66f83bebf51ec21a1fd550"
 
 def repo():
     git_repository(


### PR DESCRIPTION
## Motivation

Update XLA hash to Fix LoadKernel to use refcounted module path for proper cleanup https://github.com/ROCm/xla/commit/83511bbb674157d2db66f83bebf51ec21a1fd550


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
