### PR TITLE
Update XLA commit hash to b32df5 (Apr 20, 2026)

### DIFF
--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -13,7 +13,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 #   1. Find the commit hash you want to pin to (e.g., from rocm-jaxlib-v0.9.1 branch)
 #   2. Update XLA_COMMIT below
 
-XLA_COMMIT = "83511bbb674157d2db66f83bebf51ec21a1fd550"
+XLA_COMMIT = "b32df5f07315567cc1940388ef766b87c6e8b9e3"
 
 def repo():
     git_repository(


### PR DESCRIPTION
## Motivation

Update XLA commit hash to https://github.com/ROCm/xla/commit/b32df5f07315567cc1940388ef766b87c6e8b9e3

## Technical Details

[ROCm] Fix roctracer (v1) profiler build for rocm-jaxlib-v0.8.2
The preceding commit added RocmTracer::GpuAgents() and a matching test,
both of which only exist on the rocprofiler-sdk (v3) tracer backend.
The roctracer (v1) backend (--define=xla_rocm_profiler=v1) does not
expose these APIs, breaking //pjrt/tools:build_gpu_plugin_wheel.

Guard the v3-only call in device_tracer_rocm.cc and the v3-only tests
in rocm_tracer_test.cc with the XLA_GPU_ROCM_TRACER_BACKEND macro.
SetGpuAgents() is a no-op on the base collector, so the v1 path
preserves pre-cherrypick behavior.

## Test Plan

Rebuilt wheels and ran unit tests.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
