### PR TITLE
fixwheel: also handle manylinux_2_27 platform tag

### DIFF
--- a/jax_rocm_plugin/build/rocm/tools/fixwheel.py
+++ b/jax_rocm_plugin/build/rocm/tools/fixwheel.py
@@ -63,7 +63,7 @@ def fix_wheel(path):
     """Fixes a wheel and attaches manylinux platform labels to it"""
     tup = parse_wheel_name(path)
     plat_tag = tup[4]
-    if "manylinux2014" in plat_tag:
+    if "manylinux2014" in plat_tag or "manylinux_2_27" in plat_tag:
         # strip any manylinux tags from the current wheel first
         plat_mod_str = "linux_x86_64"
         output = subprocess.run(


### PR DESCRIPTION
## Motivation

Add "manylinux_2_27" to the platform tag check so these wheels are
also stripped to linux_x86_64 before auditwheel repairs them to
manylinux_2_28.