### PR TITLE
Update jax hash to a5a5bfd Apr 20,2026

### DIFF
--- a/jax_rocm_plugin/third_party/jax/workspace.bzl
+++ b/jax_rocm_plugin/third_party/jax/workspace.bzl
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 #   1. Find the commit hash you want to pin to (e.g., from rocm-jaxlib-v0.9.1 branch)
 #   2. Update JAX_COMMIT below
 
-JAX_COMMIT = "15f7ae2a340bf430ffc7b9711c212579ad72175b"
+JAX_COMMIT = "a5a5bfd0c1cef100b4f775bf6a2b3e9aa8327ae1"
 
 def repo():
     git_repository(


### PR DESCRIPTION
## Motivation

Update JAX hash to a5a5bfd Apr 20,2026

## Technical Details

The hash has nn_test lowering fix

## Test Plan

UTs executed

## Test Result

nn_test failures fixed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
