### PR TITLE
Build: clean manylinux_2_28 wheels + https for repo.radeon.com

### DIFF
--- a/jax_rocm_plugin/build/rocm/tools/fixwheel.py
+++ b/jax_rocm_plugin/build/rocm/tools/fixwheel.py
@@ -61,6 +61,8 @@ def parse_wheel_name(path):
 
 def fix_wheel(path):
     """Fixes a wheel and attaches manylinux platform labels to it"""
+    original_input = path
+    intermediate = None
     tup = parse_wheel_name(path)
     plat_tag = tup[4]
     if "manylinux2014" in plat_tag or "manylinux_2_27" in plat_tag:
@@ -80,6 +82,7 @@ def fix_wheel(path):
         new_wheel = output.stdout.strip()
         new_path = os.path.join(os.path.dirname(path), new_wheel)
         LOG.info("Stripped broken tags and created new wheel at %r", new_path)
+        intermediate = new_path
         path = new_path
 
     # build excludes, using auditwheels lddtree to find them
@@ -103,6 +106,23 @@ def fix_wheel(path):
     LOG.info("running %r", cmd)
 
     subprocess.run(cmd, check=True)
+
+    # auditwheel writes the clean wheel into ./wheelhouse/. Remove the Bazel
+    # input and any `wheel tags` intermediate so build_wheels.py doesn't
+    # propagate them alongside the auditwheel output (which would leave
+    # users with three differently-tagged copies of the same package in the
+    # wheelhouse).
+    if intermediate and intermediate != original_input:
+        try:
+            os.remove(intermediate)
+            LOG.info("Removed intermediate wheel %r", intermediate)
+        except OSError as exc:
+            LOG.warning("Could not remove intermediate %r: %s", intermediate, exc)
+    try:
+        os.remove(original_input)
+        LOG.info("Removed source wheel %r", original_input)
+    except OSError as exc:
+        LOG.warning("Could not remove source wheel %r: %s", original_input, exc)
 
 
 def main():

--- a/jax_rocm_plugin/build/rocm/tools/fixwheel.py
+++ b/jax_rocm_plugin/build/rocm/tools/fixwheel.py
@@ -59,7 +59,7 @@ def parse_wheel_name(path):
     return wheel_name[:-4].split("-")
 
 
-def fix_wheel(path):
+def fix_wheel(path):  # pylint: disable=too-many-locals
     """Fixes a wheel and attaches manylinux platform labels to it"""
     original_input = path
     intermediate = None

--- a/jax_rocm_plugin/jaxlib_ext/tools/build_utils.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_utils.py
@@ -66,9 +66,7 @@ def _apply_wheel_post_release(  # pylint: disable=too-many-locals
 
     def _record_hash(payload: bytes) -> str:
         digest = hashlib.sha256(payload).digest()
-        return (
-            "sha256=" + base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-        )
+        return "sha256=" + base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
     tmp_path = wheel_path + ".tmp"
     record_entries: list[tuple[str, str, int]] = []

--- a/jax_rocm_plugin/jaxlib_ext/tools/build_utils.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_utils.py
@@ -39,9 +39,17 @@ def _append_post_release_suffix(version: str, post_release: str) -> str:
 def _apply_wheel_post_release(  # pylint: disable=too-many-locals
     wheel_path: str, post_release: str | None
 ) -> str:
-    """Append a .postX version suffix into wheel filename and internal metadata."""
+    """Append a .postX version suffix into wheel filename and internal metadata.
+
+    Rewrites RECORD with valid PEP 376 hash/size entries. The original
+    implementation emitted ``path,,`` for every file, which downstream tooling
+    such as ``wheel tags`` (used by ``fixwheel.py``) rejects with
+    ``No hash found for file '<...>/WHEEL'``.
+    """
     if not post_release:
         return wheel_path
+    import base64  # pylint: disable=import-outside-toplevel
+    import hashlib  # pylint: disable=import-outside-toplevel
     import re  # pylint: disable=import-outside-toplevel
     import zipfile  # pylint: disable=import-outside-toplevel
 
@@ -56,7 +64,14 @@ def _apply_wheel_post_release(  # pylint: disable=too-many-locals
     old_dist_info = None
     new_dist_info = None
 
+    def _record_hash(payload: bytes) -> str:
+        digest = hashlib.sha256(payload).digest()
+        return (
+            "sha256=" + base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+        )
+
     tmp_path = wheel_path + ".tmp"
+    record_entries: list[tuple[str, str, int]] = []
     with zipfile.ZipFile(wheel_path, "r") as zin, zipfile.ZipFile(
         tmp_path, "w", compression=zipfile.ZIP_DEFLATED
     ) as zout:
@@ -89,11 +104,11 @@ def _apply_wheel_post_release(  # pylint: disable=too-many-locals
             info = zipfile.ZipInfo(new_name, date_time=item.date_time)
             info.compress_type = item.compress_type
             zout.writestr(info, data)
+            record_entries.append((new_name, _record_hash(data), len(data)))
 
-        record_lines = []
-        for entry in zout.namelist():
-            record_lines.append(f"{entry},,")
         record_name = f"{new_dist_info}/RECORD"
+        record_lines = [f"{name},{h},{size}" for name, h, size in record_entries]
+        # PEP 376: hash/size for the RECORD file itself MUST be empty.
         record_lines.append(f"{record_name},,")
         zout.writestr(record_name, "\n".join(record_lines) + "\n")
 

--- a/jax_rocm_plugin/pjrt/tools/build_utils.py
+++ b/jax_rocm_plugin/pjrt/tools/build_utils.py
@@ -66,9 +66,7 @@ def _apply_wheel_post_release(  # pylint: disable=too-many-locals
 
     def _record_hash(payload: bytes) -> str:
         digest = hashlib.sha256(payload).digest()
-        return (
-            "sha256=" + base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-        )
+        return "sha256=" + base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
     tmp_path = wheel_path + ".tmp"
     record_entries: list[tuple[str, str, int]] = []

--- a/jax_rocm_plugin/pjrt/tools/build_utils.py
+++ b/jax_rocm_plugin/pjrt/tools/build_utils.py
@@ -39,9 +39,17 @@ def _append_post_release_suffix(version: str, post_release: str) -> str:
 def _apply_wheel_post_release(  # pylint: disable=too-many-locals
     wheel_path: str, post_release: str | None
 ) -> str:
-    """Append a .postX version suffix into wheel filename and internal metadata."""
+    """Append a .postX version suffix into wheel filename and internal metadata.
+
+    Rewrites RECORD with valid PEP 376 hash/size entries. The original
+    implementation emitted ``path,,`` for every file, which downstream tooling
+    such as ``wheel tags`` (used by ``fixwheel.py``) rejects with
+    ``No hash found for file '<...>/WHEEL'``.
+    """
     if not post_release:
         return wheel_path
+    import base64  # pylint: disable=import-outside-toplevel
+    import hashlib  # pylint: disable=import-outside-toplevel
     import re  # pylint: disable=import-outside-toplevel
     import zipfile  # pylint: disable=import-outside-toplevel
 
@@ -56,7 +64,14 @@ def _apply_wheel_post_release(  # pylint: disable=too-many-locals
     old_dist_info = None
     new_dist_info = None
 
+    def _record_hash(payload: bytes) -> str:
+        digest = hashlib.sha256(payload).digest()
+        return (
+            "sha256=" + base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+        )
+
     tmp_path = wheel_path + ".tmp"
+    record_entries: list[tuple[str, str, int]] = []
     with zipfile.ZipFile(wheel_path, "r") as zin, zipfile.ZipFile(
         tmp_path, "w", compression=zipfile.ZIP_DEFLATED
     ) as zout:
@@ -89,11 +104,11 @@ def _apply_wheel_post_release(  # pylint: disable=too-many-locals
             info = zipfile.ZipInfo(new_name, date_time=item.date_time)
             info.compress_type = item.compress_type
             zout.writestr(info, data)
+            record_entries.append((new_name, _record_hash(data), len(data)))
 
-        record_lines = []
-        for entry in zout.namelist():
-            record_lines.append(f"{entry},,")
         record_name = f"{new_dist_info}/RECORD"
+        record_lines = [f"{name},{h},{size}" for name, h, size in record_entries]
+        # PEP 376: hash/size for the RECORD file itself MUST be empty.
         record_lines.append(f"{record_name},,")
         zout.writestr(record_name, "\n".join(record_lines) + "\n")
 

--- a/tools/get_rocm.py
+++ b/tools/get_rocm.py
@@ -427,7 +427,7 @@ def setup_repos_el8(rocm_version_str):
         rfd.write("""
 [ROCm]
 name=ROCm
-baseurl=http://repo.radeon.com/rocm/rhel8/%s/main
+baseurl=https://repo.radeon.com/rocm/rhel8/%s/main
 enabled=1
 gpgcheck=1
 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key


### PR DESCRIPTION
## Motivation

Three build/CI fixes:

1. Building the new builder image takes ages and sometimes errors out from timeout due to http mirrors being extremely slow. Switch http to https for `repo.radeon.com`.
2. Builds with `--wheel-post-release` crash mid-fixwheel after PR #392 (`No hash found for file '<...>/WHEEL'`).
3. On the runs where they do complete, `wheelhouse/` ends up with three differently- tagged copies of the same package (`…-linux_x86_64.whl`, `…-manylinux_2_27_x86_64.whl`, `…-manylinux_2_28_x86_64.whl`). TheRock's release-promotion filter only matches the clean `…-manylinux_2_28_x86_64.whl`, so the noisy output silently breaks the release path.

## Technical Details

- `tools/get_rocm.py`: http changed to https on line 430.
- `_apply_wheel_post_release` in `jax_rocm_plugin/pjrt/tools/build_utils.py` and `jax_rocm_plugin/jaxlib_ext/tools/build_utils.py` now emits PEP 376-compliant RECORD with `path,sha256=<urlsafe-b64>,size` entries; previously it wrote `path,,` for every entry, which made `wheel tags` (called by `fixwheel.py`) abort.
- `fix_wheel` in `jax_rocm_plugin/build/rocm/tools/fixwheel.py` now removes the Bazel input (`…-manylinux_2_27_x86_64.whl`) and the `wheel tags` intermediate (`…-linux_x86_64.whl`) from `dist_manylinux/` after `auditwheel repair` succeeds, so `build_wheels.py`'s blind `shutil.copy(dist_manylinux/*, wheelhouse/)` step doesn't propagate them alongside the audited output.

## Test Plan and Result

Ran ci_build, which exercises both the builder Docker rebuild and the wheel pipeline:


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
