### PR TITLE
fix(docker): ensure amdclang++ is found during MIOpen rebuild on ubu24

### DIFF
--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -144,8 +144,13 @@ RUN [ "$ROCM_VERSION" = "7.1.1" ] || (       \
     dpkg-divert --no-rename --remove /opt/rocm/lib/libMIOpen.so.1 && \
     dpkg-divert --add --package local --divert /opt/rocm/lib/libMIOpen.bak.1.0.70200 --rename /opt/rocm/lib/libMIOpen.so.1.0.70200 && \
     cd /rocm-libraries/projects/miopen/ && mkdir build && cd build && \
-    export CXX=amdclang++ &&                                          \
+    # The PATH/ENV updates at the bottom of this Dockerfile have not run yet,
+    # so amdclang++ is not on PATH. Add /opt/rocm/llvm/bin and /opt/rocm/bin
+    # explicitly and pin CXX to the absolute path so CMake can locate it.
+    export PATH="/opt/rocm/llvm/bin:/opt/rocm/bin:${PATH}" &&          \
+    export CXX=/opt/rocm/llvm/bin/amdclang++ &&                       \
     cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DMIOPEN_BACKEND=HIP     \
+          -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/amdclang++          \
           -DBUILD_TESTING=OFF -DCMAKE_PREFIX_PATH="/opt/rocm"         \
           -DMIOPEN_USE_MLIR=OFF -DMIOPEN_ENABLE_AI_KERNEL_TUNING=OFF  \
           -DMIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK=OFF .. &&            \


### PR DESCRIPTION
## Summary

Fixes the `jax-base-ubu24` Docker build failing on the `rocm-jaxlib-v0.9.1` branch with:

```
CMake Error at /usr/share/cmake-3.28/Modules/CMakeDetermineCXXCompiler.cmake:48 (message):
  Could not find compiler set in environment variable CXX:

    amdclang++.

CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
-- Configuring incomplete, errors occurred
```

## Root cause

The temporary MIOpen rebuild block in `docker/Dockerfile.base-ubu24` (added as a workaround for ROCm/rocm-libraries#4472) sets:

```dockerfile
export CXX=amdclang++
cmake ...
```

…but the `ENV PATH="$PATH:/opt/rocm/bin:/opt/rocm/llvm/bin"` directives are at the bottom of the Dockerfile and only take effect for **subsequent** `RUN` instructions, not for the one currently building MIOpen. So CMake searches `$PATH` for the bare name `amdclang++`, finds nothing, and aborts the build.

## Fix

Make the MIOpen rebuild step self-contained w.r.t. the ROCm toolchain:

1. Prepend `/opt/rocm/llvm/bin:/opt/rocm/bin` to `PATH` inside the `RUN` (so transitive lookups for `hipcc`, `llvm-link`, etc. also resolve).
2. Set `CXX` to the absolute path `/opt/rocm/llvm/bin/amdclang++` instead of relying on `PATH`.
3. Pass `-DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/amdclang++` directly to `cmake` so the project-language probe at `CMakeLists.txt:74 (project)` succeeds even if a future change ignores the `CXX` env var.

## Test plan

Verified locally end-to-end with:

```bash
python3 build/ci_build --rocm-version=7.2.0 build_base_dockers --filter ubu24
```

Before this PR: build failed at step `#16` (the MIOpen `cmake` invocation).

After this PR:

| Stage | Result |
|---|---|
| MIOpen CMake configure | `-- Check for working CXX compiler: /opt/rocm/llvm/bin/amdclang++ - skipped` ✓ `-- Configuring done (5.6s)` ✓ `-- Generating done (0.4s)` ✓ |
| `make -j10 && make install` | `#16 DONE 788.8s` ✓ |
| Image export | `#17 DONE 58.9s` ✓ |
| Final image | `jax-base-ubu24.rocm720:latest`, 26.6 GB ✓ |

- [x] Local build of `jax-base-ubu24.rocm720` succeeds with `--rocm-version=7.2.0`.
- [ ] CI nightly build green.

## Notes / follow-ups

- This whole MIOpen rebuild block is intentionally temporary. Once ROCm/rocm-libraries#4472 ships in a packaged ROCm release, lines 122–151 of `docker/Dockerfile.base-ubu24` should be deleted; this patch goes away with it.
- The `dpkg-divert ... libMIOpen.so.1.0.70200` filename on line 138 is still hardcoded for ROCm 7.2.0. If `ROCM_VERSION` is ever bumped to anything other than `7.1.1`/`7.2.0`, that filename will need updating (or, better, derived from `${ROCM_VERSION}`). Not changed in this PR to keep the diff minimal.
- Sibling Dockerfiles in this repo (`Dockerfile.jax-ubu24`, `docker/manylinux/*`) and the Dockerfiles in ROCm/jax do not invoke `amdclang++` at image-build time, so no other files need to change.

Supersedes #400.