### PR TITLE
fix(build_wheels): use full rocm_version for jaxlib wheel version suffix

### DIFF
--- a/jax_rocm_plugin/build/rocm/tools/build_wheels.py
+++ b/jax_rocm_plugin/build/rocm/tools/build_wheels.py
@@ -246,7 +246,8 @@ def build_jaxlib_wheel(
         "--verbose",
         "--bazel_options=--action_env=HIPCC_COMPILE_FLAGS_APPEND=--offload-compress",
         "--bazel_options=--repo_env=ML_WHEEL_TYPE=release",
-        f"--bazel_options=--repo_env=ML_WHEEL_VERSION_SUFFIX=+rocm{version_string}",
+        # Replace '+' with '.' for PEP 440 compliance (local version label)
+        f"--bazel_options=--repo_env=ML_WHEEL_VERSION_SUFFIX=+rocm{rocm_version.replace('+', '.')}",
     ]
 
     # Add clang path if clang is used.


### PR DESCRIPTION
## Motivation

jaxlib 0.9.0 wheels are missing the full ROCm version in their filenames. For example, the wheel is named `jaxlib-0.9.0+rocm7-cp312-cp312-manylinux_2_28_x86_64.whl` instead of the expected `jaxlib-0.9.0+rocm7.13.0a20260417-cp312-cp312-manylinux_2_28_x86_64.whl`. The 0.8.2 branch produces the correct name.

## Technical Details

In `build_jaxlib_wheel()` inside `jax_rocm_plugin/build/rocm/tools/build_wheels.py`, the `ML_WHEEL_VERSION_SUFFIX` bazel repo env was set using `version_string` instead of `rocm_version`.

`version_string` comes from `get_rocm_version_flag()`, which only returns the first character of the version (e.g. `"7"`), resulting in suffix `+rocm7`. The correct variable is `rocm_version`, which holds the full version string (e.g. `"7.13.0a20260417"`), producing suffix `+rocm7.13.0a20260417`.

This was already fixed on the `rocm-jaxlib-v0.8.2` branch via [ROCm/rocm-jax#293](https://github.com/ROCm/rocm-jax/pull/293), but was not cherry-picked to the 0.9.0 and 0.9.1 branches.

## Test Plan

- Build jaxlib wheel with `--rocm-version="7.13.0a20260417"` and verify the output wheel filename contains the full ROCm version suffix.

## Test Result

- Before fix: `jaxlib-0.9.0+rocm7-cp312-cp312-manylinux_2_28_x86_64.whl`
- After fix: `jaxlib-0.9.0+rocm7.13.0a20260417-cp312-cp312-manylinux_2_28_x86_64.whl`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.