### PR TITLE
backport: multi-Python support (3.11–3.14) from rocm-jaxlib-v0.9.0 → rocm-jaxlib-v0.8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,7 @@ jobs:
         rocm-version: ["7.1.0"]
     uses: ./.github/workflows/build-wheels.yml
     with:
-      # TODO: Add back Python 3.13 when we're ready to move to a more recent version of XLA. 3.13
-      #       fails with a complaint abou the pipes module.
-      python-versions: "3.11,3.12"
+      python-versions: "3.11,3.12,3.13,3.14"
       rocm-version: ${{ matrix.rocm-version }}
       runner-label: '["linux-x86-64-1gpu-amd"]'
     secrets:
@@ -107,4 +105,3 @@ jobs:
           python3 build/ci_build test \
             "ghcr.io/rocm/jax-ubu22.rocm${ROCM_VERSION//.}:${GITHUB_SHA}" \
             --test-cmd "bash ci/jax_rbe/pr_setup.sh && ci/jax_rbe/pr_test.sh 0.8.2 3.12"
-

--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -22,9 +22,25 @@ ARG LLVM_VERSION="none"
 ARG DEBIAN_FRONTEND=noninteractive
 
 ### Build Steps:
-# Install python3 packages and solution for breaking system package:
+# Install all Python versions from deadsnakes PPA:
 RUN --mount=type=cache,target=/var/cache/apt \
-    apt-get update && apt-get install -y python3 python-is-python3 python3-pip && \
+    apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y \
+        python3.11 python3.11-dev python3.11-venv \
+        python3.12 python3.12-dev python3.12-venv \
+        python3.13 python3.13-dev python3.13-venv \
+        python3.13-nogil \
+        python3.14 python3.14-dev python3.14-venv \
+        python3.14-nogil \
+        python3-pip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set default Python to 3.12 (most stable):
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 100 && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3.12 100 && \
     mv /usr/lib/python3.12/EXTERNALLY-MANAGED /usr/lib/python3.12/EXTERNALLY-MANAGED.old
 
 # Install bzip2 and sqlite3 packages:
@@ -75,6 +91,6 @@ ENV PATH="$OPENCL_ROOT/bin:${PATH}"
 ENV PATH="/root/bin:/root/.local/bin:$PATH"
 
 LABEL com.amdgpu.rocm_version="$ROCM_VERSION" \
-      com.amdgpu.python_version="3.12" \
+      com.amdgpu.python_versions="3.11,3.12,3.13,3.13-nogil,3.14,3.14-nogil" \
       com.amdgpu.install_llvm="$INSTALL_LLVM" \
       com.amdgpu.llvm_version="$LLVM_VERSION"

--- a/docker/Dockerfile.jax-ubu24
+++ b/docker/Dockerfile.jax-ubu24
@@ -21,39 +21,48 @@ ARG ROCM_JAX_COMMIT
 ARG PLUGIN_NAMESPACE
 
 
+# Install common dependencies for all Python versions
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
-    pip3 install --break-system-packages \
-        "numpy<2" \
-        build \
-        wheel \
-        six \
-        auditwheel \
-        scipy \
-        pytest \
-        pytest-html \
-        pytest_html_merger \
-        pytest-reportlog \
-        pytest-rerunfailures \
-        pytest-json-report \
-        cloudpickle \
-        portpicker \
-        matplotlib \
-        absl-py \
-        flatbuffers \
-        hypothesis
+    for py in python3.11 python3.12 python3.13 python3.14; do \
+        $py -m pip install --break-system-packages \
+            "numpy<2" \
+            build \
+            wheel \
+            six \
+            auditwheel \
+            scipy \
+            pytest \
+            pytest-html \
+            pytest_html_merger \
+            pytest-reportlog \
+            pytest-rerunfailures \
+            pytest-json-report \
+            cloudpickle \
+            portpicker \
+            matplotlib \
+            absl-py \
+            flatbuffers \
+            hypothesis; \
+    done
 
-# install jax and jaxlib from requirements file
+# Install jax and jaxlib from requirements file for all Python versions
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     --mount=type=bind,source=build/requirements.txt,target=requirements.txt \
-    pip3 install --break-system-packages -r requirements.txt
+    for py in python3.11 python3.12 python3.13 python3.14; do \
+        $py -m pip install --break-system-packages -r requirements.txt; \
+    done
 
 LABEL com.amdgpu.jax_version="$JAX_VERSION" \
       com.amdgpu.jax_commit="$JAX_COMMIT" \
       com.amdgpu.xla_commit="$XLA_COMMIT" \
-      com.amdgpu.rocm_jax_commit="$ROCM_JAX_COMMIT"
+      com.amdgpu.rocm_jax_commit="$ROCM_JAX_COMMIT" \
+      com.amdgpu.python_versions="3.11,3.12,3.13,3.14"
 
+# Install ROCm JAX wheels for all Python versions
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     --mount=type=bind,source=wheelhouse,target=/wheelhouse \
     ls -lah /wheelhouse && \
-    pip3 install -f /wheelhouse --no-deps --no-index "jax_rocm${PLUGIN_NAMESPACE}_plugin" "jax_rocm${PLUGIN_NAMESPACE}_pjrt" && \
-    pip3 install -f /wheelhouse --no-deps --no-index --force-reinstall "jaxlib"
+    for py in python3.11 python3.12 python3.13 python3.14; do \
+        $py -m pip install -f /wheelhouse --no-deps --no-index "jax_rocm${PLUGIN_NAMESPACE}_plugin" "jax_rocm${PLUGIN_NAMESPACE}_pjrt" && \
+        $py -m pip install -f /wheelhouse --no-deps --no-index --force-reinstall "jaxlib"; \
+    done

--- a/docker/Dockerfile.jax-ubu24
+++ b/docker/Dockerfile.jax-ubu24
@@ -23,9 +23,9 @@ ARG PLUGIN_NAMESPACE
 
 # Install common dependencies for all Python versions
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
-    for py in python3.11 python3.12 python3.13 python3.14; do \
+    set -e && for py in python3.11 python3.12 python3.13 python3.14; do \
         $py -m pip install --break-system-packages \
-            "numpy<2" \
+            numpy \
             build \
             wheel \
             six \
@@ -48,7 +48,7 @@ RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
 # Install jax and jaxlib from requirements file for all Python versions
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     --mount=type=bind,source=build/requirements.txt,target=requirements.txt \
-    for py in python3.11 python3.12 python3.13 python3.14; do \
+    set -e && for py in python3.11 python3.12 python3.13 python3.14; do \
         $py -m pip install --break-system-packages -r requirements.txt; \
     done
 
@@ -61,7 +61,7 @@ LABEL com.amdgpu.jax_version="$JAX_VERSION" \
 # Install ROCm JAX wheels for all Python versions
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     --mount=type=bind,source=wheelhouse,target=/wheelhouse \
-    ls -lah /wheelhouse && \
+    set -e && ls -lah /wheelhouse && \
     for py in python3.11 python3.12 python3.13 python3.14; do \
         $py -m pip install -f /wheelhouse --no-deps --no-index "jax_rocm${PLUGIN_NAMESPACE}_plugin" "jax_rocm${PLUGIN_NAMESPACE}_pjrt" && \
         $py -m pip install -f /wheelhouse --no-deps --no-index --force-reinstall "jaxlib"; \


### PR DESCRIPTION
## Summary

Backports multi-Python support from `rocm-jaxlib-v0.9.0` into `rocm-jaxlib-v0.8.2`.

### `docker/Dockerfile.base-ubu24`
- Add deadsnakes PPA (`ppa:deadsnakes/ppa`)
- Install Python 3.11, 3.12, 3.13, 3.13-nogil, 3.14, 3.14-nogil (with `-dev` and `-venv` variants)
- Set Python 3.12 as the system default via `update-alternatives`
- Update `LABEL` from `python_version="3.12"` → `python_versions="3.11,3.12,3.13,3.13-nogil,3.14,3.14-nogil"`

### `docker/Dockerfile.jax-ubu24`
- Replace single `pip3 install` calls with `for py in python3.11 python3.12 python3.13 python3.14` loops for:
  - Common dependency installs
  - `requirements.txt` installs
  - ROCm JAX wheel installs (`jax_rocm*_plugin`, `jax_rocm*_pjrt`, `jaxlib`)
- Add `com.amdgpu.python_versions="3.11,3.12,3.13,3.14"` LABEL

## Test plan
- [ ] Docker build of `Dockerfile.base-ubu24` succeeds with all Python versions installed
- [ ] Docker build of `Dockerfile.jax-ubu24` succeeds with wheels installed for each Python version
- [ ] `python3.11`, `python3.12`, `python3.13`, `python3.14` all importable inside the container
- [ ] `python3` defaults to 3.12

Relates to: https://amd-hub.atlassian.net/browse/ROCM-23437