### PR TITLE
Bump XLA to pick up latest rocm-jaxlib-v0.9.0 changes

### DIFF
--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -13,7 +13,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 #   1. Find the commit hash you want to pin to (e.g., from rocm-jaxlib-v0.8.2 branch)
 #   2. Update XLA_COMMIT below
 
-XLA_COMMIT = "7d76601f623c1595f3ba11ef7c9f4f8190bccfe1"
+XLA_COMMIT = "93a2897079004add540024e921b867da4ff6ea91"
 
 def repo():
     git_repository(


### PR DESCRIPTION
Update XLA commit to 93a2897079004add540024e921b867da4ff6ea91 to pick up the latest changes on ROCm/xla rocm-jaxlib-v0.9.0.