### PR TITLE
Cherry-pick Update JAX hash and Update ROCm Version to 7.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   call-build-wheels:
     strategy:
       matrix:
-        rocm-version: ["7.1.1"]
+        rocm-version: ["7.2.0"]
     uses: ./.github/workflows/build-wheels.yml
     with:
       python-versions: "3.11,3.12,3.13,3.14"
@@ -33,7 +33,7 @@ jobs:
     needs: call-build-wheels
     strategy:
       matrix:
-        rocm-version: ["7.1.1"]
+        rocm-version: ["7.2.0"]
     uses: ./.github/workflows/build-docker.yml
     with:
       rocm-version: ${{ matrix.rocm-version }}
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        rocm-version: ["7.1.1"]
+        rocm-version: ["7.2.0"]
     steps:
       - name: Change owners for cleanup
         run: |

--- a/.github/workflows/rocm-perf.yml
+++ b/.github/workflows/rocm-perf.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.12"]
-        rocm-version: ["7.1.1"]
+        rocm-version: ["7.2.0"]
 
     outputs:
       python_version: ${{ steps.meta.outputs.python }}

--- a/jax_rocm_plugin/build/rocm/ci_run_jax_ut.sh
+++ b/jax_rocm_plugin/build/rocm/ci_run_jax_ut.sh
@@ -50,7 +50,7 @@ bazel --bazelrc="${SCRIPT_DIR}/jax.bazelrc" test \
     --config=rocm \
     --test_tag_filters="${TAG_FILTERS}" \
     --build_tag_filters="${TAG_FILTERS}" \
-    --@jax//jax:build_jaxlib=wheel \
+    --@jax//jax:build_jaxlib=false \
     --keep_going \
     --test_verbose_timeout_warnings \
     --local_test_jobs=4 \

--- a/jax_rocm_plugin/third_party/jax/workspace.bzl
+++ b/jax_rocm_plugin/third_party/jax/workspace.bzl
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 #   1. Find the commit hash you want to pin to (e.g., from rocm-jaxlib-v0.9.1 branch)
 #   2. Update JAX_COMMIT below
 
-JAX_COMMIT = "a5a5bfd0c1cef100b4f775bf6a2b3e9aa8327ae1"
+JAX_COMMIT = "7f75782ad5ea6cd97e6346dcae9317ac31babef8"
 
 def repo():
     git_repository(


### PR DESCRIPTION
## Motivation
Cherry-pick https://github.com/ROCm/rocm-jax/pull/408 to 0.9.1

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
