### PR TITLE
[rocm-jaxlib-v0.9.0] Add gfx1151 (RDNA3.5) to AMDGPU build target list

### DIFF
--- a/ci/jax_rbe/pr_test.sh
+++ b/ci/jax_rbe/pr_test.sh
@@ -47,7 +47,7 @@ python3 build/build.py build --wheels=jax-rocm-plugin --configure_only --python_
     --config=rocm_rbe \
     --noremote_accept_cached \
     --//jax:build_jaxlib=false \
-    --action_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1200,gfx1201" \
+    --action_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1151,gfx1200,gfx1201" \
     --test_verbose_timeout_warnings \
     --test_output=errors \
     //tests:core_test_gpu \

--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -2,7 +2,7 @@ FROM ubuntu:24.04
 
 ### Container Build Arguments:
 # The list of target devices to be supported by the JAX ROCm plugin and pjrt.
-ARG GPU_DEVICE_TARGETS="gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1200 gfx1201"
+ARG GPU_DEVICE_TARGETS="gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1151 gfx1200 gfx1201"
 # The ROCm version to be used inside the container.
 ARG ROCM_VERSION
 # The installation path for ROCm.

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
@@ -3,7 +3,7 @@ FROM quay.io/pypa/manylinux_2_28_x86_64
 ARG ROCM_VERSION
 ARG ROCM_BUILD_JOB
 ARG ROCM_BUILD_NUM
-ENV GPU_DEVICE_TARGETS="gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1200 gfx1201"
+ENV GPU_DEVICE_TARGETS="gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1151 gfx1200 gfx1201"
 
 # Install patchelf and headers for numactl
 RUN --mount=type=cache,target=/var/cache/dnf \

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -3,7 +3,7 @@ FROM quay.io/pypa/manylinux_2_28_x86_64
 
 ARG ROCM_VERSION
 ARG THEROCK_PATH
-ENV GPU_DEVICE_TARGETS="gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1200 gfx1201"
+ENV GPU_DEVICE_TARGETS="gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1151 gfx1200 gfx1201"
 
 # Install patchelf and headers for numactl
 RUN --mount=type=cache,target=/var/cache/dnf \

--- a/jax_rocm_plugin/.bazelrc
+++ b/jax_rocm_plugin/.bazelrc
@@ -91,7 +91,7 @@ build:rocm_base --config=clang_local
 build:rocm_base --crosstool_top=@local_config_rocm//crosstool:toolchain
 build:rocm_base --define=using_rocm=true --define=using_rocm_hipcc=true
 build:rocm_base --repo_env TF_NEED_ROCM=1
-build:rocm_base --action_env TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1200,gfx1201"
+build:rocm_base --action_env TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1151,gfx1200,gfx1201"
 
 # Build with hipcc for ROCm and clang for the host.
 build:rocm --config=rocm_base

--- a/jax_rocm_plugin/build/build.py
+++ b/jax_rocm_plugin/build/build.py
@@ -240,7 +240,7 @@ def add_artifact_subcommand_arguments(parser: argparse.ArgumentParser):
     rocm_group.add_argument(
         "--rocm_amdgpu_targets",
         type=str,
-        default="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1200,gfx1201",
+        default="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1151,gfx1200,gfx1201",
         help="A comma-separated list of ROCm amdgpu targets to support.",
     )
 

--- a/jax_rocm_plugin/build/rocm/build_wheels/Dockerfile.manylinux_2_28_x86_64.rocm
+++ b/jax_rocm_plugin/build/rocm/build_wheels/Dockerfile.manylinux_2_28_x86_64.rocm
@@ -11,7 +11,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     python3 get_rocm.py --rocm-version=$ROCM_VERSION --job-name=$ROCM_BUILD_JOB --build-num=$ROCM_BUILD_NUM --therock-path=$THEROCK_PATH
 ENV PATH="$PATH:/opt/rocm/bin:/opt/rocm/llvm/bin"
 
-ARG GPU_DEVICE_TARGETS="gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1200 gfx1201"
+ARG GPU_DEVICE_TARGETS="gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1151 gfx1200 gfx1201"
 RUN printf '%s\n' > /opt/rocm/bin/target.lst ${GPU_DEVICE_TARGETS}
 
 # Install LLVM 18 and dependencies.

--- a/jax_rocm_plugin/build/rocm/setup.rocm.sh
+++ b/jax_rocm_plugin/build/rocm/setup.rocm.sh
@@ -94,6 +94,6 @@ echo "$ROCM_PATH"
 echo "$GPU_DEVICE_TARGETS"
 
 # Ensure the ROCm target list is set up
-GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS:-"gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1200 gfx1201"}
+GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS:-"gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1151 gfx1200 gfx1201"}
 printf '%s\n' "${GPU_DEVICE_TARGETS}" | tee -a "$ROCM_PATH/bin/target.lst"
 touch "${ROCM_PATH}/.info/version"

--- a/jax_rocm_plugin/build/rocm/tools/build_wheels.py
+++ b/jax_rocm_plugin/build/rocm/tools/build_wheels.py
@@ -39,7 +39,7 @@ LOG = logging.getLogger(__name__)
 
 
 GPU_DEVICE_TARGETS = (
-    "gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1200 gfx1201"
+    "gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1151 gfx1200 gfx1201"
 )
 
 

--- a/stack.py
+++ b/stack.py
@@ -17,7 +17,7 @@ DEFAULT_KERNELS_JAX_DIR = "../jax"
 
 MAKE_TEMPLATE = r"""
 # gfx targets for which XLA and jax custom call kernels are built for
-# AMDGPU_TARGETS ?= "gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1200,gfx1201"
+# AMDGPU_TARGETS ?= "gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1151,gfx1200,gfx1201"
 
 # customize to a single arch for local dev builds to reduce compile time
 AMDGPU_TARGETS ?= "$(shell rocminfo | grep -o -m 1 'gfx.*')"


### PR DESCRIPTION
Adds `gfx1151` to the explicit AMDGPU target list used to build the ROCm jaxlib + plugin + pjrt wheels and the Docker base images.