### PR TITLE
fix(docker): ensure amdclang++ is found during MIOpen rebuild on ubu24

### DIFF
--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -144,8 +144,13 @@ RUN [ "$ROCM_VERSION" = "7.1.1" ] || (       \
     dpkg-divert --no-rename --remove /opt/rocm/lib/libMIOpen.so.1 && \
     dpkg-divert --add --package local --divert /opt/rocm/lib/libMIOpen.bak.1.0.70200 --rename /opt/rocm/lib/libMIOpen.so.1.0.70200 && \
     cd /rocm-libraries/projects/miopen/ && mkdir build && cd build && \
-    export CXX=amdclang++ &&                                          \
+    # The PATH/ENV updates at the bottom of this Dockerfile have not run yet,
+    # so amdclang++ is not on PATH. Add /opt/rocm/llvm/bin and /opt/rocm/bin
+    # explicitly and pin CXX to the absolute path so CMake can locate it.
+    export PATH="/opt/rocm/llvm/bin:/opt/rocm/bin:${PATH}" &&          \
+    export CXX=/opt/rocm/llvm/bin/amdclang++ &&                       \
     cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DMIOPEN_BACKEND=HIP     \
+          -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/amdclang++          \
           -DBUILD_TESTING=OFF -DCMAKE_PREFIX_PATH="/opt/rocm"         \
           -DMIOPEN_USE_MLIR=OFF -DMIOPEN_ENABLE_AI_KERNEL_TUNING=OFF  \
           -DMIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK=OFF .. &&            \


### PR DESCRIPTION
The temporary MIOpen rebuild block in docker/Dockerfile.base-ubu24 sets `export CXX=amdclang++`, but the `ENV PATH=":/opt/rocm/llvm/bin"` lines at the bottom of the Dockerfile only take effect for *subsequent* RUN instructions. As a result CMake searches $PATH for the bare name `amdclang++`, can't find it, and aborts the base-ubu24 image build with:

    CMake Error: Could not find compiler set in environment variable CXX:
      amdclang++.
    CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage

Make the MIOpen build step self-contained w.r.t. the ROCm toolchain:

  * prepend /opt/rocm/llvm/bin and /opt/rocm/bin to PATH inside the RUN so transitive tool lookups (hipcc, llvm-link, etc.) also work,
  * set CXX to the absolute path /opt/rocm/llvm/bin/amdclang++,
  * pass -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/amdclang++ to cmake so the project-language probe at CMakeLists.txt:74 succeeds even if a future change ignores the CXX env var.

Verified locally with:
    python3 build/ci_build --rocm-version=7.2.0 build_base_dockers --filter ubu24

CMake configure now succeeds:
    -- Check for working CXX compiler: /opt/rocm/llvm/bin/amdclang++ - skipped -- Configuring done (5.6s) -- Generating done (0.4s)

and the full image (jax-base-ubu24.rocm720, 26.6 GB) is produced.

Note: this entire MIOpen rebuild block is temporary and should be removed once ROCm/rocm-libraries#4472 lands in a packaged ROCm release.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
