### PR TITLE
restore custom MIOpen rebuild for ROCm 7.2.2

### DIFF
--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -129,8 +129,7 @@ RUN --mount=type=cache,target=/var/cache/apt   \
 # Temporarily include a custom built MIOpen. This should be removed
 # as soon as https://github.com/ROCm/rocm-libraries/pull/4472 lands
 # in a ROCm release that we can install as deb package or with therock.
-# Fix is already included in ROCm 7.2.2 and later, so skip the rebuild there.
-RUN [ "$ROCM_VERSION" = "7.1.1" ] || [ "$ROCM_VERSION" = "7.2.2" ] || (       \
+RUN [ "$ROCM_VERSION" = "7.1.1" ] || (       \
     git clone https://github.com/ROCm/rocm-libraries.git --branch fix/stack-overflow-kernel-init --depth 1 /rocm-libraries && \
     apt update &&                              \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Commit 4b1a95a ("Upgrade ROCm base images from 7.2.0 to 7.2.2") added [ "$ROCM_VERSION" = "7.2.2" ] to the MIOpen rebuild guard on the assumption that ROCm/rocm-libraries#4472 (fix/stack-overflow-kernel-init) was already in 7.2.2's MIOpen package.

Empirically that fix is NOT in the shipped MIOpen 3.5.1.70202-86.el8 package. A single jax.lax.conv from inside the
ghcr.io/rocm/jax-manylinux_2_28-rocm-7.2.2 image SIGSEGVs on MI355X (gfx950) at:

    #0  miopen::kernels[abi:cxx11]()           libMIOpen.so.1
    #1  miopen::GetKernelSrc(...)              libMIOpen.so.1
    #2  miopen::HIPOCProgramImpl::BuildCodeObject(...)
    ...
    #16 stream_executor::gpu::MIOpenSupport::PopulateMIOpenFindDb
    ...
    #25 xla::gpu::AutotunerPass::RunImpl
    
    
    so adding the changes back.
