### PR TITLE
Revert "Upgrade ROCm base images from 7.2.0 to 7.2.2 (#399)"

### DIFF
--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -26,12 +26,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rocm-version: ["7.1.1", "7.2.2"]
+        rocm-version: ["7.1.1", "7.2.0"]
         install-llvm: [true, false]
         include:
           - rocm-version: "7.1.1"
             runner-label: "linux-x86-64-1gpu-amd"
-          - rocm-version: "7.2.2"
+          - rocm-version: "7.2.0"
             runner-label: "linux-x86-64-1gpu-amd"
     steps:
       - name: Clean up old runs
@@ -84,7 +84,7 @@ jobs:
           INSTALL_LLVM: ${{ matrix.install-llvm }}
         run: |
           # Construct image tag based on matrix values
-          # ROCm version tag removes dots (7.1.1 -> 711, 7.2.2 -> 722)
+          # ROCm version tag removes dots (7.1.1 -> 711, 7.2.0 -> 720)
           rocm_tag="rocm${ROCM_VERSION//.}"
           if [ "$INSTALL_LLVM" = "true" ]; then
             image_tag="jax-dev-ubu24.${rocm_tag}"
@@ -120,11 +120,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rocm-version: ["7.1.1", "7.2.2"]
+        rocm-version: ["7.1.1", "7.2.0"]
         include:
           - rocm-version: "7.1.1"
             runner-label: "linux-x86-64-1gpu-amd"
-          - rocm-version: "7.2.2"
+          - rocm-version: "7.2.0"
             runner-label: "linux-x86-64-1gpu-amd"
     steps:
       - name: Clean up old runs

--- a/.github/workflows/ci-ut.yml
+++ b/.github/workflows/ci-ut.yml
@@ -1,0 +1,96 @@
+name: CI Unit Tests
+
+on:
+  push:
+    branches:
+      - master
+      - 'rocm-jaxlib-v*'
+  pull_request:
+    branches:
+      - master
+      - 'rocm-jaxlib-v*'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: build-and-test (${{ matrix.mode.name }})
+    runs-on: linux-x86-64-4gpu-amd
+    strategy:
+      fail-fast: false
+      matrix:
+        mode:
+          - {name: "py3.11", python_version: "3.11", config: ""}
+          - {name: "py3.12", python_version: "3.12", config: ""}
+          - {name: "py3.13", python_version: "3.13", config: ""}
+          - {name: "py3.14", python_version: "3.14", config: ""}
+          - {name: "asan", python_version: "3.11", config: "--config=asan"}
+    container:
+      # note this image shall match the one defined in platform/linux:tf_linux_gpu
+      image: rocm/tensorflow-build@sha256:7fcfbd36b7ac8f6b0805b37c4248e929e31cf5ee3af766c8409dd70d5ab65faa
+      options: >-
+        -w ${{ github.workspace }}/jax_rocm_plugin
+        --device=/dev/kfd
+        --device=/dev/dri
+        --group-add video
+        --cap-add=SYS_PTRACE
+        --security-opt seccomp=unconfined
+        --shm-size 16G
+    defaults:
+      run:
+        working-directory: jax_rocm_plugin
+    steps:
+      - name: Checkout plugin repo
+        uses: actions/checkout@v4
+
+      - name: Get RBE cluster keys
+        env:
+          RBE_CI_CERT: ${{ secrets.RBE_CI_CERT }}
+          RBE_CI_KEY: ${{ secrets.RBE_CI_KEY }}
+        run: |
+          echo "$RBE_CI_CERT" >> ci-cert.crt
+          echo "$RBE_CI_KEY" >> ci-cert.key
+
+      - name: Run single-GPU unit tests
+        if: always()
+        run: |
+          bash build/rocm/ci_run_jax_ut.sh \
+            --config=rocm_sgpu \
+            --config=rocm_rbe \
+            --repo_env=HERMETIC_PYTHON_VERSION=${{ matrix.mode.python_version }} \
+            ${{ matrix.mode.config }} \
+            --curses=no \
+            --color=yes \
+            -- \
+            @jax//tests:gpu_tests \
+            @jax//tests:backend_independent_tests \
+            $(build/rocm/targets_to_ignore.sh)
+
+      - name: Run multi-GPU unit tests
+        if: always()
+        run: |
+          bash build/rocm/ci_run_jax_ut.sh \
+            --config=rocm_mgpu \
+            --config=rocm_rbe \
+            --repo_env=HERMETIC_PYTHON_VERSION=${{ matrix.mode.python_version }} \
+            ${{ matrix.mode.config }} \
+            --curses=no \
+            --color=yes \
+            --strategy=TestRunner=local \
+            -- \
+            @jax//tests:gpu_tests \
+            @jax//tests:backend_independent_tests \
+            $(build/rocm/targets_to_ignore.sh)
+
+      - name: Upload logs to artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-rbe-py${{ matrix.mode.name }}
+          path: jax_rocm_plugin/logs/

--- a/.github/workflows/nightly-rbe.yml
+++ b/.github/workflows/nightly-rbe.yml
@@ -1,0 +1,83 @@
+name: Nightly RBE
+
+on:
+  schedule:
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/nightly-rbe.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: linux-x86-64-4gpu-amd
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.11", "3.12", "3.13", "3.14"]
+    container:
+      # note this image shall match the one defined in platform/linux:tf_linux_gpu
+      image: rocm/tensorflow-build@sha256:7fcfbd36b7ac8f6b0805b37c4248e929e31cf5ee3af766c8409dd70d5ab65faa
+      options: >-
+        -w ${{ github.workspace }}/jax_rocm_plugin
+        --device=/dev/kfd
+        --device=/dev/dri
+        --group-add video
+        --cap-add=SYS_PTRACE
+        --security-opt seccomp=unconfined
+        --shm-size 16G
+    defaults:
+      run:
+        working-directory: jax_rocm_plugin
+    steps:
+      - name: Checkout plugin repo
+        uses: actions/checkout@v4
+
+      - name: Get RBE cluster keys
+        env:
+          RBE_CI_CERT: ${{ secrets.RBE_CI_CERT }}
+          RBE_CI_KEY: ${{ secrets.RBE_CI_KEY }}
+        run: |
+          echo "$RBE_CI_CERT" >> ci-cert.crt
+          echo "$RBE_CI_KEY" >> ci-cert.key
+
+      - name: Run single-GPU unit tests (Python ${{ matrix.python_version }})
+        if: always()
+        run: |
+          bash build/rocm/ci_run_jax_ut.sh \
+            --config=rocm_sgpu \
+            --config=rocm_rbe \
+            --repo_env=HERMETIC_PYTHON_VERSION=${{ matrix.python_version }} \
+            --curses=no \
+            --color=yes \
+            -- \
+            @jax//tests:gpu_tests \
+            @jax//tests:backend_independent_tests
+
+      - name: Run multi-GPU unit tests (Python ${{ matrix.python_version }})
+        if: always()
+        run: |
+          bash build/rocm/ci_run_jax_ut.sh \
+            --config=rocm_mgpu \
+            --config=rocm_rbe \
+            --repo_env=HERMETIC_PYTHON_VERSION=${{ matrix.python_version }} \
+            --curses=no \
+            --color=yes \
+            --strategy=TestRunner=local \
+            -- \
+            @jax//tests:gpu_tests \
+            @jax//tests:backend_independent_tests
+
+      - name: Upload logs to artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-rbe-py${{ matrix.python_version }}
+          path: jax_rocm_plugin/logs/

--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -129,8 +129,7 @@ RUN --mount=type=cache,target=/var/cache/apt   \
 # Temporarily include a custom built MIOpen. This should be removed
 # as soon as https://github.com/ROCm/rocm-libraries/pull/4472 lands
 # in a ROCm release that we can install as deb package or with therock.
-# Fix is already included in ROCm 7.2.2 and later, so skip the rebuild there.
-RUN [ "$ROCM_VERSION" = "7.1.1" ] || [ "$ROCM_VERSION" = "7.2.2" ] || (       \
+RUN [ "$ROCM_VERSION" = "7.1.1" ] || (       \
     git clone https://github.com/ROCm/rocm-libraries.git --branch fix/stack-overflow-kernel-init --depth 1 /rocm-libraries && \
     apt update &&                              \
     apt-get install -y --no-install-recommends \
@@ -167,9 +166,8 @@ ENV MIOPEN_FIND_ENFORCE=SEARCH_DB_UPDATE
 # The profiler SDK's intercept queue corrupts AQL packets when they wrap
 # around the ring buffer boundary, causing HSA_STATUS_ERROR_INVALID_PACKET_FORMAT
 # aborts under parallel GPU workloads.
-# Fix is already included in ROCm 7.2.2 and later, so skip the rebuild there.
 RUN --mount=type=bind,source=docker/patches/rocr-intercept-queue-fix.patch,target=/tmp/rocr-fix.patch \
-    [ "$ROCM_VERSION" = "7.1.1" ] || [ "$ROCM_VERSION" = "7.2.2" ] || (                 \
+    [ "$ROCM_VERSION" = "7.1.1" ] || (                 \
     apt-get update && apt-get install -y --no-install-recommends \
         cmake pkg-config libelf-dev libdrm-dev libnuma-dev rocm-llvm-dev xxd && \
     git clone --filter=blob:none --no-checkout --depth=1 \

--- a/jax_rocm_plugin/build/rocm/jax.bazelrc
+++ b/jax_rocm_plugin/build/rocm/jax.bazelrc
@@ -21,3 +21,21 @@ build:rocm_sgpu --build_tag_filters=jax_test_gpu,-multiaccelerator,-config-cuda-
 
 # for @xla//build_tools/rocm:parallel_gpu_execute
 build:rocm --legacy_external_runfiles=true
+
+build:rocm_rbe --bes_backend="grpcs://wardite.cluster.engflow.com"
+build:rocm_rbe --bes_results_url="https://wardite.cluster.engflow.com/invocation/"
+build:rocm_rbe --host_platform="//platform/linux:tf_linux_gpu"
+build:rocm_rbe --extra_execution_platforms="//platform/linux:tf_linux_gpu"
+build:rocm_rbe --platforms="//platform/linux:tf_linux_gpu"
+build:rocm_rbe --bes_timeout=600s
+build:rocm_rbe --tls_client_certificate="ci-cert.crt"
+build:rocm_rbe --tls_client_key="ci-cert.key"
+build:rocm_rbe --spawn_strategy=local
+build:rocm_rbe --grpc_keepalive_time=30s
+build:rocm_rbe --test_sharding_strategy=disabled
+build:rocm_rbe --action_env=REMOTE_GPU_TESTING=1
+
+test:rocm_rbe --jobs=200
+test:rocm_rbe --remote_executor=grpcs://wardite.cluster.engflow.com
+test:rocm_rbe --remote_timeout=3600
+test:rocm_rbe --strategy=TestRunner=remote,local

--- a/jax_rocm_plugin/platform/linux/BUILD
+++ b/jax_rocm_plugin/platform/linux/BUILD
@@ -28,3 +28,18 @@ platform(
         "Pool": "linux_x64_gpu",
     },
 )
+
+platform(
+    name = "tf_linux_gpu",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+        "@bazel_tools//tools/cpp:clang",
+    ],
+    # note this image shall match the container one executes the build command!
+    exec_properties = {
+        "container-image": "docker://rocm/tensorflow-build@sha256:7fcfbd36b7ac8f6b0805b37c4248e929e31cf5ee3af766c8409dd70d5ab65faa",
+        "OSFamily": "Linux",
+        "Pool": "linux_x64_gpu",
+    },
+)

--- a/tools/get_rocm.py
+++ b/tools/get_rocm.py
@@ -29,7 +29,6 @@ import shutil
 import ssl
 import subprocess
 import sys
-import urllib.error
 import urllib.parse
 import urllib.request
 
@@ -373,37 +372,6 @@ Pin-Priority: 600
 """
 
 
-def _graphics_url_version(rocm_version_str):
-    """Pick the right /graphics/<version>/ path component on repo.radeon.com.
-
-    AMD does not always publish a per-patch graphics subfolder (e.g. as of
-    now /graphics/7.2.2/ 404s while /rocm/.../7.2.2/ exists). Try the full
-    version first; fall back to major.minor so ROCm patch releases keep
-    working even when the graphics driver lags.
-    """
-    rv = parse_version(rocm_version_str)
-    major_minor = "%d.%d" % (rv.major, rv.minor)
-
-    if rocm_version_str == major_minor:
-        return rocm_version_str
-
-    probe_url = "https://repo.radeon.com/graphics/%s/" % rocm_version_str
-    try:
-        req = urllib.request.Request(probe_url, method="HEAD")
-        with urllib.request.urlopen(req, timeout=10) as response:
-            if 200 <= response.status < 400:
-                LOG.info("Graphics repo: using full-version path %s", rocm_version_str)
-                return rocm_version_str
-    except (urllib.error.HTTPError, urllib.error.URLError) as exc:
-        LOG.info(
-            "Graphics repo: %s unavailable (%s); falling back to %s",
-            probe_url,
-            exc,
-            major_minor,
-        )
-    return major_minor
-
-
 def setup_repos_ubuntu(rocm_version_str):
     """Configure an apt sources list entry for ROCm."""
 
@@ -412,11 +380,6 @@ def setup_repos_ubuntu(rocm_version_str):
     # if X.Y.0 -> repo url version should be X.Y
     if rv.rev == 0:
         rocm_version_str = "%d.%d" % (rv.major, rv.minor)
-
-    # AMD does not always publish a per-patch graphics subfolder (e.g.
-    # /graphics/7.2.2/ 404s while /rocm/apt/7.2.2/ exists), so probe and
-    # fall back to major.minor for the amdgpu/graphics URL when needed.
-    graphics_version = _graphics_url_version(rocm_version_str)
 
     # update indexes before prereq install, for fresh docker images
     subprocess.check_call(["apt-get", "update"])
@@ -433,7 +396,7 @@ def setup_repos_ubuntu(rocm_version_str):
     with open("/etc/apt/sources.list.d/amdgpu.list", "w") as fd:
         fd.write(
             ("deb [arch=amd64] " "https://repo.radeon.com/graphics/%s/ubuntu %s main\n")
-            % (graphics_version, codename)
+            % (rocm_version_str, codename)
         )
 
     with open("/etc/apt/sources.list.d/rocm.list", "w") as fd:
@@ -459,11 +422,6 @@ def setup_repos_el8(rocm_version_str):
     # if X.Y.0 -> repo url version should be X.Y
     if rv.rev == 0:
         rocm_version_str = "%d.%d" % (rv.major, rv.minor)
-
-    # AMD does not always publish a per-patch graphics subfolder (e.g.
-    # /graphics/7.2.2/ 404s while /rocm/rhel8/7.2.2/ exists), so probe and
-    # fall back to major.minor for the amdgpu/graphics URL when needed.
-    graphics_version = _graphics_url_version(rocm_version_str)
 
     with open("/etc/yum.repos.d/rocm.repo", "w") as rfd:
         rfd.write("""
@@ -491,7 +449,7 @@ gpgcheck=1
 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
 timeout=1000
 minrate=1
-""" % (repodir, graphics_version))
+""" % (repodir, rocm_version_str))
 
 
 def parse_args():


### PR DESCRIPTION
Reverts commit 4b1a95ae1d4ecf9031e1f7534668e774601283a6 on master.

as per our discussion for now we are sticking with 7.2.0 hence reverting the change.