### PR TITLE
feat(docker): add core container layer

### DIFF
--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -21,7 +21,35 @@ on:
       - 'docker/manylinux/*'
 
 jobs:
+  build-core-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build core docker image
+        run: |
+          python3 build/ci_build build_core_dockers --filter="ubu24"
+      - name: Authenticate to GitHub Container Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Push docker images
+        run: |
+          image_tag="jax-core-ubu24"
+          ghcr_image_sha="ghcr.io/rocm/${image_tag}:${GITHUB_SHA}"
+          echo "Image name (SHA): ${ghcr_image_sha}"
+          docker tag "${image_tag}" "${ghcr_image_sha}"
+          docker push "${ghcr_image_sha}"
+      - name: Push latest tag
+        if: github.event_name != 'pull_request'
+        run: |
+          image_tag="jax-core-ubu24"
+          ghcr_image_latest="ghcr.io/rocm/${image_tag}:latest"
+          echo "Image name (latest): ${ghcr_image_latest}"
+          docker tag "${image_tag}" "${ghcr_image_latest}"
+          docker push "${ghcr_image_latest}"
+
   build-base-images:
+    needs: build-core-image
     runs-on: ${{ matrix.runner-label }}
     strategy:
       fail-fast: false
@@ -73,6 +101,7 @@ jobs:
             $BUILD_ARGS \
             build_base_dockers \
             --filter="ubu24" \
+            --core-image-tag="${{ github.sha }}" \
             ${{ matrix.install-llvm && '--install-llvm --llvm-version 18' || '' }}
       - name: Authenticate to GitHub Container Registry
         run: |

--- a/build/ci_build
+++ b/build/ci_build
@@ -183,6 +183,36 @@ def build_manylinux_dockers(
     return constructed_tag
 
 
+CORE_IMAGE_NAME = "ghcr.io/rocm/jax-core-ubu24"
+
+
+def build_core_dockers(
+    docker_filters=None,
+    push_latest=False,
+):
+    """Build the core Ubuntu + Python image (no ROCm, no tooling)."""
+    dockerfiles = _apply_filters(docker_filters, "Dockerfile.core")
+
+    for dockerfile in dockerfiles:
+        _, tag_suffix = dockerfile.split(".", 1)
+        tag = "jax-" + tag_suffix
+
+        print("Building dockerfile=%r to tag=%r" % (dockerfile, tag))
+
+        cmd = [
+            "docker",
+            "build",
+            "-f",
+            dockerfile,
+            "--tag=%s" % tag,
+            ".",
+        ]
+        subprocess.check_call(cmd)
+
+        if push_latest:
+            _tag_and_push_latest(tag)
+
+
 def dist_wheels(
     rocm_version,
     python_versions,
@@ -491,12 +521,26 @@ def build_base_dockers(
     docker_filters=None,
     push_latest=False,
     no_cache=False,
+    core_image_tag="latest",
 ):
+    core_image = "%s:%s" % (CORE_IMAGE_NAME, core_image_tag)
+    if not _check_base_image_exists(core_image):
+        print("Core image %s not found in registry. Building it..." % core_image)
+        build_core_dockers(
+            docker_filters=docker_filters,
+            push_latest=True,
+        )
+        core_image_tag = "latest"
+    else:
+        print("Core image %s found in registry." % core_image)
+
     dockerfiles = _apply_filters(docker_filters, "Dockerfile.base")
     # Docker tags cannot contain '+', so replace it with '.' for consistency with wheel versions
     rocm_ver_tag = "rocm%s" % "".join(rocm_version.split(".")).replace("+", ".")
 
-    extra_args = []
+    extra_args = [
+        "--build-arg=CORE_IMAGE_TAG=%s" % core_image_tag,
+    ]
     if no_cache:
         extra_args.extend(["--no-cache", "--pull"])
     if add_llvm:
@@ -720,6 +764,17 @@ def parse_args():
         help="Build images from scratch without using Docker layer cache",
     )
 
+    bcoredp = subp.add_parser(
+        "build_core_dockers", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    bcoredp.add_argument(
+        "--filter",
+        "-f",
+        type=str,
+        help="Comma separated strings to filter Dockerfiles to build. Substring match",
+        default="",
+    )
+
     bbasedp = subp.add_parser(
         "build_base_dockers", formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
@@ -745,6 +800,12 @@ def parse_args():
         help="Set the version number of LLVM to be installed.",
         type=int,
         default="18",
+    )
+    bbasedp.add_argument(
+        "--core-image-tag",
+        help="Tag of the core image to use as base for the base images.",
+        type=str,
+        default="latest",
     )
 
     testp = subp.add_parser(
@@ -799,7 +860,14 @@ def main():
             include_rocm_version_extra=not args.no_rocm_version_extra,
         )
 
-    if args.action == "build_dockers":
+    if args.action == "build_core_dockers":
+        filters = args.filter.split(",")
+
+        build_core_dockers(
+            docker_filters=filters,
+        )
+
+    elif args.action == "build_dockers":
         filters = args.filter.split(",")
 
         build_dockers(
@@ -824,6 +892,7 @@ def main():
             add_llvm=args.install_llvm,
             llvm_version=args.llvm_version,
             no_cache=args.no_cache,
+            core_image_tag=args.core_image_tag,
         )
 
     elif args.action == "test_docker":

--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -1,4 +1,8 @@
-FROM ubuntu:24.04
+### Container Build Arguments:
+# Tag for the core image (Ubuntu + Python only)
+ARG CORE_IMAGE_TAG=latest
+
+FROM ghcr.io/rocm/jax-core-ubu24:${CORE_IMAGE_TAG}
 
 ### Container Build Arguments:
 # The list of target devices to be supported by the JAX ROCm plugin and pjrt.
@@ -22,27 +26,6 @@ ARG LLVM_VERSION="none"
 ARG DEBIAN_FRONTEND=noninteractive
 
 ### Build Steps:
-# Install all Python versions from deadsnakes PPA:
-RUN --mount=type=cache,target=/var/cache/apt \
-    apt-get update && \
-    apt-get install -y software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa && \
-    apt-get update && \
-    apt-get install -y \
-        python3.11 python3.11-dev python3.11-venv \
-        python3.12 python3.12-dev python3.12-venv \
-        python3.13 python3.13-dev python3.13-venv \
-        python3.13-nogil \
-        python3.14 python3.14-dev python3.14-venv \
-        python3.14-nogil \
-        python3-pip && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Set default Python to 3.12 (most stable):
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 100 && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.12 100 && \
-    mv /usr/lib/python3.12/EXTERNALLY-MANAGED /usr/lib/python3.12/EXTERNALLY-MANAGED.old
-
 # Install bzip2 and sqlite3 packages:
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile.core-ubu24
+++ b/docker/Dockerfile.core-ubu24
@@ -1,0 +1,29 @@
+FROM ubuntu:24.04
+
+### Build-time only variables:
+ARG DEBIAN_FRONTEND=noninteractive
+
+### Build Steps:
+# Install all Python versions from deadsnakes PPA:
+RUN echo 'Acquire::ForceIPv4 "true";' | tee /etc/apt/apt.conf.d/99force-ipv4
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+      software-properties-common ca-certificates gpg-agent && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y \
+        python3.11 python3.11-dev python3.11-venv \
+        python3.12 python3.12-dev python3.12-venv \
+        python3.13 python3.13-dev python3.13-venv \
+        python3.13-nogil \
+        python3.14 python3.14-dev python3.14-venv \
+        python3.14-nogil \
+        python3-pip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set default Python to 3.12 (most stable):
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 100 && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3.12 100 && \
+    mv /usr/lib/python3.12/EXTERNALLY-MANAGED /usr/lib/python3.12/EXTERNALLY-MANAGED.old
+
+LABEL com.amdgpu.python_versions="3.11,3.12,3.13,3.13-nogil,3.14,3.14-nogil"


### PR DESCRIPTION
## Summary

- Introduces a new `Dockerfile.core-ubu24` containing only Ubuntu 24.04 + Python 3.11-3.14 from deadsnakes PPA, built on **public GitHub runners** (`ubuntu-latest`) to reduce AMD GPU runner usage for the OS/Python layer.
- `Dockerfile.base-ubu24` now derives from the core image instead of raw `ubuntu:24.04`, removing its duplicated Python installation steps.
- `build-base-docker.yml` gains a `build-core-image` job that runs first; `build-base-images` depends on it via `needs:` and pins the exact core image by commit SHA.
- `build/ci_build` gains a `build_core_dockers` subcommand and fallback logic in `build_base_dockers` to build the core image on-the-fly if it's missing from GHCR.

Manylinux builder images are intentionally unchanged — they require `quay.io/pypa/manylinux_2_28_x86_64` for glibc ABI compatibility.
