### PR TITLE
Tighten base image deps for deadsnakes PPA setup

### DIFF
--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -25,7 +25,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install all Python versions from deadsnakes PPA:
 RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update && \
-    apt-get install -y software-properties-common && \
+    apt-get install --no-install-recommends -y \
+      software-properties-common ca-certificates gpg-agent && \
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
- Add ca-certificates and gpg-agent to ensure secure PPA addition
- Use --no-install-recommends to minimize unnecessary package installs
- Improve reliability of Python installation by ensuring all prerequisites
- Reduce image bloat and potential attack surface by limiting packages

