### PR TITLE
[ROCm] Dynamic TheRock image tags and manylinux python fix

### DIFF
--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -162,11 +162,13 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           INSTALL_LLVM: ${{ matrix.install-llvm }}
+          THEROCK_VERSION: ${{ matrix.therock-version }}
         run: |
+          ver_slug="${THEROCK_VERSION:-latest}"
           if [ "$INSTALL_LLVM" = "true" ]; then
-            image_tag="jax-dev-ubu24.therock-latest"
+            image_tag="jax-dev-ubu24.therock-${ver_slug}"
           else
-            image_tag="jax-base-ubu24.therock-latest"
+            image_tag="jax-base-ubu24.therock-${ver_slug}"
           fi
 
           # Push with commit SHA tag
@@ -228,8 +230,11 @@ jobs:
               -u ${{ github.actor }} --password-stdin
       - name: Push docker images
         if: github.event_name != 'pull_request'
+        env:
+          THEROCK_VERSION: ${{ matrix.therock-version }}
         run: |
-          image_tag="jax-manylinux_2_28-therock-latest"
+          ver_slug="${THEROCK_VERSION:-latest}"
+          image_tag="jax-manylinux_2_28-therock-${ver_slug}"
 
           # Push with commit SHA tag
           ghcr_sha="ghcr.io/rocm/${image_tag}:${GITHUB_SHA}"

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -25,6 +25,9 @@ ENV ROCM_HOME=/opt/rocm
 ENV PATH="/opt/rocm/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rocm/lib"
 
+RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/local/bin/python && \
+    python -m ensurepip && python -m pip install auditwheel
+
 # Install LLVM 18 from source (manylinux has no apt):
 RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y wget && dnf clean all


### PR DESCRIPTION
## Summary

- Make push steps in `build-therock-base-images` and `build-therock-manylinux-images` derive image tags dynamically from `matrix.therock-version` instead of hardcoding `therock-latest`. Empty version falls back to `latest` via `${VAR:-latest}`. This enables building and pushing pinned TheRock version images alongside the latest nightly.
- Add `python` symlink and `auditwheel` to the TheRock manylinux image. The manylinux base image (`quay.io/pypa/manylinux_2_28`) only has versioned Python binaries under `/opt/python/`. JAX CI scripts call bare `python`, causing `command not found`.

## Test plan

- [x] Trigger `Build Base Docker Images` workflow and verify TheRock images build and push with dynamic tags
- [x] Verify `build_rocm_artifacts.sh` runs successfully in the TheRock manylinux container (no more `python: command not found`)