### PR TITLE
Fix ROCm plugin PJRT dependency versioning

### DIFF
--- a/jax_rocm_plugin/jaxlib_ext/tools/build_utils.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_utils.py
@@ -95,6 +95,14 @@ def _apply_wheel_post_release(  # pylint: disable=too-many-locals
                         count=1,
                         flags=re.MULTILINE,
                     )
+                    text = re.sub(
+                        r"^(Requires-Dist:\s+jax-rocm\d+-pjrt==)"
+                        + re.escape(old_version)
+                        + r"(\s*(?:;.*)?)$",
+                        rf"\g<1>{new_version}\2",
+                        text,
+                        flags=re.MULTILINE,
+                    )
                     data = text.encode("utf-8")
                 elif item.filename.endswith("/RECORD"):
                     continue

--- a/jax_rocm_plugin/pjrt/tools/build_utils.py
+++ b/jax_rocm_plugin/pjrt/tools/build_utils.py
@@ -95,6 +95,14 @@ def _apply_wheel_post_release(  # pylint: disable=too-many-locals
                         count=1,
                         flags=re.MULTILINE,
                     )
+                    text = re.sub(
+                        r"^(Requires-Dist:\s+jax-rocm\d+-pjrt==)"
+                        + re.escape(old_version)
+                        + r"(\s*(?:;.*)?)$",
+                        rf"\g<1>{new_version}\2",
+                        text,
+                        flags=re.MULTILINE,
+                    )
                     data = text.encode("utf-8")
                 elif item.filename.endswith("/RECORD"):
                     continue


### PR DESCRIPTION
## Motivation

Fix ROCm plugin wheel metadata so jax-rocm7-plugin depends on the exact matching jax-rocm7-pjrt wheel while still supporting post-release wheel rebuilds.

Fixes https://github.com/ROCm/TheRock/issues/5075

## Technical Details

The post-release wheel rewrite now updates both the wheel Version and the plugin wheel’s Requires-Dist: jax-rocm*-pjrt==... metadata. This preserves exact dependency alignment across normal releases, post releases, ROCm-local-tagged wheels, and --no-rocm-version-extra builds.


## Test Plan

Manually built wheels for all four combinations:

- ROCm tag + post release
- no ROCm tag + post release
- ROCm tag + no post release
- no ROCm tag + no post release

## Test Result

Verified built wheel metadata shows exact matching PJRT dependencies for all tested combinations.
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
