### PR TITLE
Cherry-pick: fix ROCm plugin PJRT dependency versioning

### DIFF
--- a/jax_rocm_plugin/jaxlib_ext/tools/build_utils.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_utils.py
@@ -95,6 +95,14 @@ def _apply_wheel_post_release(  # pylint: disable=too-many-locals
                         count=1,
                         flags=re.MULTILINE,
                     )
+                    text = re.sub(
+                        r"^(Requires-Dist:\s+jax-rocm\d+-pjrt==)"
+                        + re.escape(old_version)
+                        + r"(\s*(?:;.*)?)$",
+                        rf"\g<1>{new_version}\2",
+                        text,
+                        flags=re.MULTILINE,
+                    )
                     data = text.encode("utf-8")
                 elif item.filename.endswith("/RECORD"):
                     continue

--- a/jax_rocm_plugin/pjrt/tools/build_utils.py
+++ b/jax_rocm_plugin/pjrt/tools/build_utils.py
@@ -95,6 +95,14 @@ def _apply_wheel_post_release(  # pylint: disable=too-many-locals
                         count=1,
                         flags=re.MULTILINE,
                     )
+                    text = re.sub(
+                        r"^(Requires-Dist:\s+jax-rocm\d+-pjrt==)"
+                        + re.escape(old_version)
+                        + r"(\s*(?:;.*)?)$",
+                        rf"\g<1>{new_version}\2",
+                        text,
+                        flags=re.MULTILINE,
+                    )
                     data = text.encode("utf-8")
                 elif item.filename.endswith("/RECORD"):
                     continue


### PR DESCRIPTION
Cherry-picking :
https://github.com/ROCm/rocm-jax/pull/422

Fix ROCm plugin wheel metadata so jax-rocm7-plugin depends on the exact matching jax-rocm7-pjrt wheel while still supporting post-release wheel rebuilds.

Fixes https://github.com/ROCm/TheRock/issues/5075