### PR TITLE
fix(docker): scope MIOpen patch to ROCm 7.2.x only

### DIFF
--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -122,7 +122,7 @@ RUN --mount=type=cache,target=/var/cache/apt   \
 # Temporarily include a custom built MIOpen. This should be removed
 # as soon as https://github.com/ROCm/rocm-libraries/pull/4472 lands
 # in a ROCm release that we can install as deb package or with therock.
-RUN [ "$ROCM_VERSION" = "7.1.1" ] || (       \
+RUN [ "${ROCM_VERSION%.*}" != "7.2" ] || (    \
     git clone https://github.com/ROCm/rocm-libraries.git --branch fix/stack-overflow-kernel-init --depth 1 /rocm-libraries && \
     apt update &&                              \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- Restricts the custom MIOpen from-source rebuild to only the ROCm 7.2.x series, rather than running for every version except 7.1.1.
- Uses POSIX shell parameter expansion (`${ROCM_VERSION%.*}`) to check major.minor, so 7.2.0, 7.2.1, etc. trigger the patch while 7.1.x, 7.12.x, and beyond skip it.

## Test plan
- [x] Build the base image with `ROCM_VERSION=7.2.0` — MIOpen patch should execute.
- [x] Build the base image with `ROCM_VERSION=7.1.1` — MIOpen patch should be skipped.