### PR TITLE
Use deploy key for private repo checkout in Llama Perf workflow

### DIFF
--- a/.github/workflows/llama-perf.yml
+++ b/.github/workflows/llama-perf.yml
@@ -168,7 +168,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: AMD-AGI/scif_repro
-          token: ${{ secrets.SECRET_TOKEN }}
+          ssh-key: ${{ secrets.SECRET_TOKEN }}
       - name: Download JAX wheels
         env:
           GH_TOKEN: ${{ secrets.SECRET_TOKEN }}

--- a/.github/workflows/llama-perf.yml
+++ b/.github/workflows/llama-perf.yml
@@ -84,7 +84,7 @@ jobs:
           echo "label=MI355" >> $GITHUB_OUTPUT
       - name: Authenticate to GitHub Container Registry
         run: |
-          echo "${{ secrets.SECRET_TOKEN }}" \
+          echo "${{ secrets.GITHUB_TOKEN }}" \
             | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Run Container for ${{ matrix.jax-version }}
         run: |
@@ -170,8 +170,6 @@ jobs:
           repository: AMD-AGI/scif_repro
           ssh-key: ${{ secrets.SECRET_TOKEN }}
       - name: Download JAX wheels
-        env:
-          GH_TOKEN: ${{ secrets.SECRET_TOKEN }}
         run: |
           if [ "${{ matrix.jax-version }}" == "0.6.0" ]; then
             mkdir -p wheelhouse
@@ -186,22 +184,6 @@ jobs:
               jax_rocm7_pjrt==0.10.0.* \
               jax_rocm7_plugin==0.10.0.* \
               --no-deps
-          else
-            gh run download \
-              $(gh run list \
-                -R ROCm/rocm-jax \
-                -w nightly.yml \
-                -L 2000 \
-                --json databaseId,event,createdAt \
-                -q '
-                  map(select(
-                    .event == "schedule"))
-                  | max_by(.createdAt)
-                  | .databaseId') \
-              -R ROCm/rocm-jax \
-              -n plugin_wheels_r7.2.0 \
-              -D wheelhouse
-            rm -v wheelhouse/*311*
           fi
       - name: Download TE wheel artifact
         uses: actions/download-artifact@v4
@@ -247,7 +229,7 @@ jobs:
             model.mha_use_transformer_engine=True;optimizer.total_steps=200;' bazel_run_anynode.sh
       - name: Authenticate to GitHub Container Registry
         run: |
-          echo "${{ secrets.SECRET_TOKEN }}" \
+          echo "${{ secrets.GITHUB_TOKEN }}" \
             | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Run Container for ${{ matrix.jax-version }} and ${{ matrix.model-name }}
         run: |


### PR DESCRIPTION
This PR use SSH deploy key authentication for private repo checkout in Llama Perf workflow. It also replaces remaining token usage with `GITHUB_TOKEN` and removes unused authentication-related code pieces. 