### PR TITLE
Cherry-pick #430 to rocm-jaxlib-v0.9.2: Fix ROCm version formatting in image name construction

### DIFF
--- a/build/ci_build
+++ b/build/ci_build
@@ -134,11 +134,12 @@ def _construct_manylinux_builder_image_name(
     rocm_version, rocm_build_job="", rocm_build_num="", therock_path=None
 ):
     """Create an image name that includes the ROCm ersion, build job, build number, etc"""
+    sanitized_version = rocm_version.replace("+", ".")
     return (
         "{base_name}-{rocm_type}-{rocm_version}{rocm_build_job}{rocm_build_num}".format(
             base_name=MANYLINUX_IMAGE_BASE_NAME,
             rocm_type="therock" if therock_path else "rocm",
-            rocm_version=rocm_version,
+            rocm_version=sanitized_version,
             rocm_build_job="-%s" % rocm_build_job if rocm_build_job else "",
             rocm_build_num="-%s" % rocm_build_num if rocm_build_num else "",
         )


### PR DESCRIPTION
Restores the '+' -> '.' sanitization in
_construct_manylinux_builder_image_name that was present on
rocm-jaxlib-v0.9.0

---

Cherry-picked from ROCm/rocm-jax#430 (merge commit `73258f6592259d04ab1a97cb3aad178e5c481650`, originally landed on `rocm-jaxlib-v0.9.1`).