### PR TITLE
Update ci_build : Strip '+' from ROCm version when exporting ROCM_VER…

### DIFF
--- a/jax_rocm_plugin/build/rocm/ci_build
+++ b/jax_rocm_plugin/build/rocm/ci_build
@@ -114,6 +114,11 @@ def dist_wheels(
     # NOTE: GIT_DIR and GIT_WORK_TREE are NOT set because they interfere with
     # Bazel's git_repository rule. Instead, we pass ROCM_JAX_COMMIT explicitly.
     rocm_jax_commit = get_rocm_jax_commit()
+
+    # Strip '+' for PEP 440: setup.py concatenates these env vars into the
+    # wheel version local segment, which only allows a single '+' (cf. #430).
+    rocm_version_pep440 = rocm_version.replace("+", ".")
+
     cmd.extend(
         [
             "--init",
@@ -122,9 +127,9 @@ def dist_wheels(
             "64G",
             "-e",
             "ROCM_VERSION_EXTRA="
-            + (rocm_version if include_rocm_version_extra else ""),
+            + (rocm_version_pep440 if include_rocm_version_extra else ""),
             "-e",
-            "ROCM_VERSION=" + rocm_version,
+            "ROCM_VERSION=" + rocm_version_pep440,
             "-e",
             "THEROCK_BUILD=" + os.environ.get("THEROCK_BUILD", ""),
             "-e",


### PR DESCRIPTION
…SION/ROCM_VERSION_EXTRA

Follow-up to #430. 
PR #430 restored `+` → `.` sanitization for the
docker **image tag**, which fixed `docker pull/inspect` on TheRock ROCm versions like `7.13.0.dev0+<gitsha>`. 

The same `+`-laden value is still passed unchanged one layer deeper as the `ROCM_VERSION` / `ROCM_VERSION_EXTRA` env vars on the build container, where `jax_rocm_plugin/{pjrt/python,jax_plugins/rocm}/setup.py` concatenate it directly into the wheel's PEP 440 version string:

```python
__version__ = "<base>" + "+rocm" + os.getenv("ROCM_VERSION_EXTRA")