### PR TITLE
Fix ROCm version formatting in build container env vars

### DIFF
--- a/jax_rocm_plugin/build/rocm/ci_build
+++ b/jax_rocm_plugin/build/rocm/ci_build
@@ -114,6 +114,11 @@ def dist_wheels(
     # NOTE: GIT_DIR and GIT_WORK_TREE are NOT set because they interfere with
     # Bazel's git_repository rule. Instead, we pass ROCM_JAX_COMMIT explicitly.
     rocm_jax_commit = get_rocm_jax_commit()
+
+    # Strip '+' for PEP 440: setup.py concatenates these env vars into the
+    # wheel version local segment, which only allows a single '+' (cf. #430).
+    sanitized_version = rocm_version.replace("+", ".")
+
     cmd.extend(
         [
             "--init",
@@ -122,9 +127,9 @@ def dist_wheels(
             "64G",
             "-e",
             "ROCM_VERSION_EXTRA="
-            + (rocm_version if include_rocm_version_extra else ""),
+            + (sanitized_version if include_rocm_version_extra else ""),
             "-e",
-            "ROCM_VERSION=" + rocm_version,
+            "ROCM_VERSION=" + sanitized_version,
             "-e",
             "THEROCK_BUILD=" + os.environ.get("THEROCK_BUILD", ""),
             "-e",


### PR DESCRIPTION
Follow-up to #430. The '+' -> '.' sanitization PR #430 added for the docker image tag is also needed for the ROCM_VERSION_EXTRA / ROCM_VERSION env vars passed to the build container, which setup.py concatenates into the wheel version. 

Without it, TheRock builds whose
ROCM_VERSION_EXTRA contains a '+' (e.g. "7.13.0.dev0+<gitsha>") produce an invalid PEP 440 version like "0.9.1+rocm7.13.0.dev0+<sha>" and crash setuptools with packaging.version.InvalidVersion.