### PR TITLE
[v0.9.2] Apply rpath fixes to remove the necessity for creating symlinks for theRock

### DIFF
--- a/build/ci_build
+++ b/build/ci_build
@@ -146,6 +146,28 @@ def _construct_manylinux_builder_image_name(
     )
 
 
+def _get_rocm_sdk_target_family(therock_path):
+    """Get TheRock target family from env or a gfx... segment in --therock-path."""
+    target_family = os.environ.get("ROCM_SDK_TARGET_FAMILY", "").strip()
+    if target_family:
+        return target_family
+
+    # Last segment must start with a letter so trailing version digits are skipped.
+    match = re.search(
+        r"(?<![A-Za-z0-9])"
+        r"(gfx[0-9A-Za-z]+(?:[-_][0-9A-Za-z]+)*?[-_][A-Za-z][0-9A-Za-z]*)"
+        r"(?![A-Za-z0-9])",
+        therock_path or "",
+    )
+    if match:
+        return match.group(1)
+
+    raise ValueError(
+        "TheRock wheel builds require ROCM_SDK_TARGET_FAMILY or a "
+        "--therock-path containing a gfx target family, e.g. gfx950-dcgpu."
+    )
+
+
 def build_manylinux_dockers(
     rocm_version, rocm_build_job="", rocm_build_num="", therock_path=None, tag=None
 ):
@@ -251,6 +273,7 @@ def dist_wheels(
     env = os.environ.copy()
     if therock_path:
         env["THEROCK_BUILD"] = "1"
+        env["ROCM_SDK_TARGET_FAMILY"] = _get_rocm_sdk_target_family(therock_path)
     subprocess.check_call(cmd, cwd=jax_plugin_dir, env=env)
 
 

--- a/jax_rocm_plugin/build/rocm/ci_build
+++ b/jax_rocm_plugin/build/rocm/ci_build
@@ -133,6 +133,8 @@ def dist_wheels(
             "-e",
             "THEROCK_BUILD=" + os.environ.get("THEROCK_BUILD", ""),
             "-e",
+            "ROCM_SDK_TARGET_FAMILY=" + os.environ.get("ROCM_SDK_TARGET_FAMILY", ""),
+            "-e",
             "ROCM_JAX_COMMIT=" + rocm_jax_commit,
             builder_image,
             "bash",

--- a/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
@@ -21,6 +21,7 @@ build process. Most users should not run this script directly; use build.py inst
 import argparse
 import os
 import pathlib
+import re
 import shutil
 import stat
 import subprocess
@@ -107,7 +108,6 @@ parser.add_argument(
     default="",
     help="rocm/jax Git hash. Empty if unknown.",
 )
-
 args = parser.parse_args()
 
 
@@ -211,6 +211,22 @@ def get_jax_commit_hash():
     return args.jax_commit
 
 
+def get_therock_rocm_sdk_libraries_dir():
+    """Return the TheRock ROCm libraries payload dir for RUNPATH entries."""
+    target_family = os.getenv("ROCM_SDK_TARGET_FAMILY", "").strip().replace("-", "_")
+    # Strip trailing all-digit segments accidentally appended (e.g. "..._7").
+    target_family = re.sub(r"(?:_\d+)+$", "", target_family)
+    if target_family:
+        return f"_rocm_sdk_libraries_{target_family}"
+
+    if os.getenv("THEROCK_BUILD"):
+        raise RuntimeError(
+            "TheRock wheel builds require ROCM_SDK_TARGET_FAMILY. Set it "
+            "directly or pass --therock-path with a gfx target family."
+        )
+    return None
+
+
 def prepare_wheel_rocm(wheel_sources_path: pathlib.Path, *, cpu, rocm_version, srcs):
     # pylint: disable=too-many-locals
     """Assembles a source tree for the rocm kernel wheel in `sources_path`."""
@@ -285,16 +301,24 @@ def prepare_wheel_rocm(wheel_sources_path: pathlib.Path, *, cpu, rocm_version, s
         f"_triton.{pyext}",
         f"rocm_plugin_extension.{pyext}",
     ]
-    runpath = ":".join(
-        [
-            "$ORIGIN/../rocm/lib",
-            "$ORIGIN/../rocm/lib/rocm_sysdeps/lib",
-            "$ORIGIN/../../rocm/lib",
-            "$ORIGIN/../../rocm/lib/rocm_sysdeps/lib",
-            "/opt/rocm/lib",
-            "/opt/rocm/lib/rocm_sysdeps/lib",
-        ]
-    )
+    # TheRock: libs live under site-packages/_rocm_sdk_{core,libraries_<family>}/lib.
+    runpath_entries = [
+        "$ORIGIN/../_rocm_sdk_core/lib",
+        "$ORIGIN/../../_rocm_sdk_core/lib",
+        "$ORIGIN/../_rocm_sdk_core/lib/rocm_sysdeps/lib",
+        "$ORIGIN/../../_rocm_sdk_core/lib/rocm_sysdeps/lib",
+    ]
+    rocm_sdk_libraries_dir = get_therock_rocm_sdk_libraries_dir()
+    if rocm_sdk_libraries_dir:
+        runpath_entries.extend(
+            [
+                f"$ORIGIN/../{rocm_sdk_libraries_dir}/lib",
+                f"$ORIGIN/../../{rocm_sdk_libraries_dir}/lib",
+            ]
+        )
+    # Legacy ROCm: flat /opt/rocm/lib install.
+    runpath_entries.append("/opt/rocm/lib")
+    runpath = ":".join(runpath_entries)
     # patchelf --set-rpath $RUNPATH $so
     for f in files:
         so_path = os.path.join(plugin_dir, f)

--- a/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
+++ b/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
@@ -21,6 +21,7 @@ build process. Most users should not run this script directly; use build.py inst
 import argparse
 import os
 import pathlib
+import re
 import shutil
 import stat
 import subprocess
@@ -194,6 +195,22 @@ def get_jax_commit_hash():
     return args.jax_commit
 
 
+def get_therock_rocm_sdk_libraries_dir():
+    """Return the TheRock ROCm libraries payload dir for RUNPATH entries."""
+    target_family = os.getenv("ROCM_SDK_TARGET_FAMILY", "").strip().replace("-", "_")
+    # Strip trailing all-digit segments accidentally appended (e.g. "..._7").
+    target_family = re.sub(r"(?:_\d+)+$", "", target_family)
+    if target_family:
+        return f"_rocm_sdk_libraries_{target_family}"
+
+    if os.getenv("THEROCK_BUILD"):
+        raise RuntimeError(
+            "TheRock wheel builds require ROCM_SDK_TARGET_FAMILY. Set it "
+            "directly or pass --therock-path with a gfx target family."
+        )
+    return None
+
+
 def prepare_rocm_plugin_wheel(
     wheel_sources_path: pathlib.Path, *, cpu, rocm_version, srcs
 ):
@@ -247,16 +264,24 @@ def prepare_rocm_plugin_wheel(
         raise RuntimeError(mesg) from ex
 
     shared_obj_path = os.path.join(plugin_dir, "xla_rocm_plugin.so")
-    runpath = ":".join(
-        [
-            "$ORIGIN/../rocm/lib",
-            "$ORIGIN/../rocm/lib/rocm_sysdeps/lib",
-            "$ORIGIN/../../rocm/lib",
-            "$ORIGIN/../../rocm/lib/rocm_sysdeps/lib",
-            "/opt/rocm/lib",
-            "/opt/rocm/lib/rocm_sysdeps/lib",
-        ]
-    )
+    # TheRock: libs live under site-packages/_rocm_sdk_{core,libraries_<family>}/lib.
+    runpath_entries = [
+        "$ORIGIN/../_rocm_sdk_core/lib",
+        "$ORIGIN/../../_rocm_sdk_core/lib",
+        "$ORIGIN/../_rocm_sdk_core/lib/rocm_sysdeps/lib",
+        "$ORIGIN/../../_rocm_sdk_core/lib/rocm_sysdeps/lib",
+    ]
+    rocm_sdk_libraries_dir = get_therock_rocm_sdk_libraries_dir()
+    if rocm_sdk_libraries_dir:
+        runpath_entries.extend(
+            [
+                f"$ORIGIN/../{rocm_sdk_libraries_dir}/lib",
+                f"$ORIGIN/../../{rocm_sdk_libraries_dir}/lib",
+            ]
+        )
+    # Legacy ROCm: flat /opt/rocm/lib install.
+    runpath_entries.append("/opt/rocm/lib")
+    runpath = ":".join(runpath_entries)
     # patchelf --set-rpath $RUNPATH $so
     fix_perms = False
     perms = os.stat(shared_obj_path).st_mode


### PR DESCRIPTION
## Summary

Cherry-pick of ROCm/rocm-jax#438 onto `rocm-jaxlib-v0.9.2`. Original PR was merged onto `rocm-jaxlib-v0.9.1` as `6ac05b35ed7196164b88d12b27c400e8520b5ebd`.

## Motivation

TheRock-installed JAX wheels currently require a global `rm -rf /opt/rocm && ln -s "$(rocm-sdk path --root)" /opt/rocm` because the wheels' RUNPATH only knows `/opt/rocm/lib`. This PR makes the wheels load directly from the TheRock site-packages layout, while preserving legacy `/opt/rocm` behavior.

## Technical Details

- `build/ci_build`: derive `ROCM_SDK_TARGET_FAMILY` from env or a `gfx...` segment in `--therock-path`; reject TheRock builds without one. Regex requires the last `[-_]` segment to start with a letter so trailing version digits aren't captured.
- `jax_rocm_plugin/build/rocm/ci_build`: forward `ROCM_SDK_TARGET_FAMILY` into the Docker wheel build.
- `jax_rocm_plugin/{jaxlib_ext,pjrt}/tools/build_gpu_*_wheel.py`: build RUNPATH from the env (with a defensive trim of trailing `_<digits>`):

```
$ORIGIN/{..,../..}/_rocm_sdk_core/lib
$ORIGIN/{..,../..}/_rocm_sdk_core/lib/rocm_sysdeps/lib
$ORIGIN/{..,../..}/_rocm_sdk_libraries_<family>/lib    # only when family is set
/opt/rocm/lib
```

- Both `..` and `../..` cover the two install depths; `rocm_sysdeps` covers TheRock's bundled `librocm_sysdeps_*.so.1` direct deps.

