### PR TITLE
Use all known TheRock target families in RUNPATH so that our wheels find host theRock .so file libs path

### DIFF
--- a/build/ci_build
+++ b/build/ci_build
@@ -141,28 +141,6 @@ def _construct_manylinux_builder_image_name(rocm_version, rocm_build_job="", roc
     )
 
 
-def _get_rocm_sdk_target_family(therock_path):
-    """Get TheRock target family from env or a gfx... segment in --therock-path."""
-    target_family = os.environ.get("ROCM_SDK_TARGET_FAMILY", "").strip()
-    if target_family:
-        return target_family
-
-    # Last segment must start with a letter so trailing version digits are skipped.
-    match = re.search(
-        r"(?<![A-Za-z0-9])"
-        r"(gfx[0-9A-Za-z]+(?:[-_][0-9A-Za-z]+)*?[-_][A-Za-z][0-9A-Za-z]*)"
-        r"(?![A-Za-z0-9])",
-        therock_path or "",
-    )
-    if match:
-        return match.group(1)
-
-    raise ValueError(
-        "TheRock wheel builds require ROCM_SDK_TARGET_FAMILY or a "
-        "--therock-path containing a gfx target family, e.g. gfx950-dcgpu."
-    )
-
-
 def build_manylinux_dockers(
     rocm_version, rocm_build_job="", rocm_build_num="", therock_path=None, tag=None
 ):
@@ -264,7 +242,6 @@ def dist_wheels(
     env = os.environ.copy()
     if therock_path:
         env["THEROCK_BUILD"] = "1"
-        env["ROCM_SDK_TARGET_FAMILY"] = _get_rocm_sdk_target_family(therock_path)
     subprocess.check_call(cmd, cwd=jax_plugin_dir, env=env)
 
 

--- a/jax_rocm_plugin/build/rocm/ci_build
+++ b/jax_rocm_plugin/build/rocm/ci_build
@@ -133,8 +133,6 @@ def dist_wheels(
             "-e",
             "THEROCK_BUILD=" + os.environ.get("THEROCK_BUILD", ""),
             "-e",
-            "ROCM_SDK_TARGET_FAMILY=" + os.environ.get("ROCM_SDK_TARGET_FAMILY", ""),
-            "-e",
             "ROCM_JAX_COMMIT=" + rocm_jax_commit,
             builder_image,
             "bash",

--- a/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
@@ -21,7 +21,6 @@ build process. Most users should not run this script directly; use build.py inst
 import argparse
 import os
 import pathlib
-import re
 import shutil
 import stat
 import subprocess
@@ -162,20 +161,26 @@ def get_jax_commit_hash():
     return args.jax_commit
 
 
-def get_therock_rocm_sdk_libraries_dir():
-    """Return the TheRock ROCm libraries payload dir for RUNPATH entries."""
-    target_family = os.getenv("ROCM_SDK_TARGET_FAMILY", "").strip().replace("-", "_")
-    # Strip trailing all-digit segments accidentally appended (e.g. "..._7").
-    target_family = re.sub(r"(?:_\d+)+$", "", target_family)
-    if target_family:
-        return f"_rocm_sdk_libraries_{target_family}"
-
-    if os.getenv("THEROCK_BUILD"):
-        raise RuntimeError(
-            "TheRock wheel builds require ROCM_SDK_TARGET_FAMILY. Set it "
-            "directly or pass --therock-path with a gfx target family."
-        )
-    return None
+# Every known TheRock target family. Each user installs one of the matching
+# rocm-sdk-libraries-<family> wheels for their GPU; the loader silently skips
+# the entries whose dirs don't exist in site-packages.
+_THEROCK_TARGET_FAMILIES = (
+    "gfx950-dcgpu",
+    "gfx94X-dcgpu",
+    "gfx90a",
+    "gfx90X-dcgpu",
+    "gfx908",
+    "gfx906",
+    "gfx900",
+    "gfx120X-all",
+    "gfx1153",
+    "gfx1152",
+    "gfx1151",
+    "gfx1150",
+    "gfx110X-all",
+    "gfx103X-all",
+    "gfx101X-dgpu",
+)
 
 
 def prepare_wheel_rocm(wheel_sources_path: pathlib.Path, *, cpu, rocm_version, srcs):
@@ -259,14 +264,10 @@ def prepare_wheel_rocm(wheel_sources_path: pathlib.Path, *, cpu, rocm_version, s
         "$ORIGIN/../_rocm_sdk_core/lib/rocm_sysdeps/lib",
         "$ORIGIN/../../_rocm_sdk_core/lib/rocm_sysdeps/lib",
     ]
-    rocm_sdk_libraries_dir = get_therock_rocm_sdk_libraries_dir()
-    if rocm_sdk_libraries_dir:
-        runpath_entries.extend(
-            [
-                f"$ORIGIN/../{rocm_sdk_libraries_dir}/lib",
-                f"$ORIGIN/../../{rocm_sdk_libraries_dir}/lib",
-            ]
-        )
+    for family in _THEROCK_TARGET_FAMILIES:
+        family_dir = "_rocm_sdk_libraries_" + family.replace("-", "_")
+        runpath_entries.append(f"$ORIGIN/../{family_dir}/lib")
+        runpath_entries.append(f"$ORIGIN/../../{family_dir}/lib")
     # Legacy ROCm: flat /opt/rocm/lib install.
     runpath_entries.append("/opt/rocm/lib")
     runpath = ":".join(runpath_entries)

--- a/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
+++ b/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
@@ -21,7 +21,6 @@ build process. Most users should not run this script directly; use build.py inst
 import argparse
 import os
 import pathlib
-import re
 import shutil
 import stat
 import subprocess
@@ -159,20 +158,26 @@ def get_jax_commit_hash():
     return args.jax_commit
 
 
-def get_therock_rocm_sdk_libraries_dir():
-    """Return the TheRock ROCm libraries payload dir for RUNPATH entries."""
-    target_family = os.getenv("ROCM_SDK_TARGET_FAMILY", "").strip().replace("-", "_")
-    # Strip trailing all-digit segments accidentally appended (e.g. "..._7").
-    target_family = re.sub(r"(?:_\d+)+$", "", target_family)
-    if target_family:
-        return f"_rocm_sdk_libraries_{target_family}"
-
-    if os.getenv("THEROCK_BUILD"):
-        raise RuntimeError(
-            "TheRock wheel builds require ROCM_SDK_TARGET_FAMILY. Set it "
-            "directly or pass --therock-path with a gfx target family."
-        )
-    return None
+# Every known TheRock target family. Each user installs one of the matching
+# rocm-sdk-libraries-<family> wheels for their GPU; the loader silently skips
+# the entries whose dirs don't exist in site-packages.
+_THEROCK_TARGET_FAMILIES = (
+    "gfx950-dcgpu",
+    "gfx94X-dcgpu",
+    "gfx90a",
+    "gfx90X-dcgpu",
+    "gfx908",
+    "gfx906",
+    "gfx900",
+    "gfx120X-all",
+    "gfx1153",
+    "gfx1152",
+    "gfx1151",
+    "gfx1150",
+    "gfx110X-all",
+    "gfx103X-all",
+    "gfx101X-dgpu",
+)
 
 
 def prepare_rocm_plugin_wheel(
@@ -204,10 +209,11 @@ def prepare_rocm_plugin_wheel(
 
     build_utils.update_setup_with_rocm_version(wheel_sources_path, rocm_version)
     write_setup_cfg(wheel_sources_path, cpu)
-    xla_commit_hash = get_xla_commit_hash()
-    jax_commit_hash = get_jax_commit_hash()
     build_utils.write_commit_info(
-        plugin_dir, xla_commit_hash, jax_commit_hash, get_rocm_jax_git_hash()
+        plugin_dir,
+        get_xla_commit_hash(),
+        get_jax_commit_hash(),
+        get_rocm_jax_git_hash(),
     )
 
     # NOTE(mrodden): this is a hack to change/set rpath values
@@ -235,14 +241,10 @@ def prepare_rocm_plugin_wheel(
         "$ORIGIN/../_rocm_sdk_core/lib/rocm_sysdeps/lib",
         "$ORIGIN/../../_rocm_sdk_core/lib/rocm_sysdeps/lib",
     ]
-    rocm_sdk_libraries_dir = get_therock_rocm_sdk_libraries_dir()
-    if rocm_sdk_libraries_dir:
-        runpath_entries.extend(
-            [
-                f"$ORIGIN/../{rocm_sdk_libraries_dir}/lib",
-                f"$ORIGIN/../../{rocm_sdk_libraries_dir}/lib",
-            ]
-        )
+    for family in _THEROCK_TARGET_FAMILIES:
+        family_dir = "_rocm_sdk_libraries_" + family.replace("-", "_")
+        runpath_entries.append(f"$ORIGIN/../{family_dir}/lib")
+        runpath_entries.append(f"$ORIGIN/../../{family_dir}/lib")
     # Legacy ROCm: flat /opt/rocm/lib install.
     runpath_entries.append("/opt/rocm/lib")
     runpath = ":".join(runpath_entries)


### PR DESCRIPTION
## Motivation

The previous RPATH implementation required ROCM_SDK_TARGET_FAMILY to be set at build time, tying each built wheel to a single TheRock target family. Users installing rocm-sdk-libraries-gfx94X-dcgpu on a wheel built with gfx950-dcgpu would fail to resolve math libraries like libhipblas.so.3 and libMIOpen.so.1.

## Technical Details

- Replaced the ROCM_SDK_TARGET_FAMILY-driven single-family RUNPATH lookup with a hardcoded _THEROCK_TARGET_FAMILIES tuple listing all 15 known TheRock families (gfx950-dcgpu through gfx101X-dgpu) in both build_gpu_kernels_wheel.py and build_gpu_plugin_wheel.py.
- RUNPATH now unconditionally includes $ORIGIN/{..,../..}/_rocm_sdk_libraries_<family>/lib for every family. The dynamic loader silently skips entries whose dirs don't exist, so only the user's installed family is actually searched.
- Removed _get_rocm_sdk_target_family() and the regex parsing from build/ci_build; removed -e ROCM_SDK_TARGET_FAMILY=... forwarding from jax_rocm_plugin/build/rocm/ci_build. No build-time target family input is required anymore.

## Test Plan

- readelf -d + ldd on the installed .sos in TheRock and legacy containers.
- Full ci/run_pytest_rocm.sh on MI350 (gfx950-dcgpu) and MI300X (gfx94X-dcgpu) using the same wheel built from the gfx950-dcgpu TheRock index, plus legacy /opt/rocm-7.2.0.

## Test Result

- MI350 / gfx950-dcgpu (TheRock): 28021 pass, 2 fail (pre-existing flakes).
- MI300X / gfx94X-dcgpu (TheRock, same wheel): 28021 pass, 2 fail (pre-existing flakes).


- ## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
