### PR TITLE
[ROCm] Set ROCM_PATH in manylinux Dockerfile to avoid hermetic build issues

### DIFF
--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
@@ -45,3 +45,9 @@ RUN ln -s /usr/bin/python3.11 /usr/local/bin/python
 # Use the symlinked Python to bootstrap pip and install the auditwheel
 # package. This is required for the JAX CI scripts.
 RUN python -m ensurepip && python -m pip install auditwheel
+
+# This is not strictly required, but it's here to mitigate an issue
+# triggered by the logic in hermetic builds (hipcc_configure.bzl)
+# that uses the existance of ROCM_PATH to use the local ROCm
+# installation.
+ENV ROCM_PATH=/opt/rocm

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
@@ -42,6 +42,12 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 # CI scripts currently require this so we symlink Python to Python3.
 RUN ln -s /usr/bin/python3.11 /usr/local/bin/python
 
+# ld.lld (hermetic linker) resolves -lstdc++ by looking for the unversioned
+# libstdc++.so in the sysroot. AlmaLinux 8 only ships libstdc++.so.6 in
+# /usr/lib64; the linker script lives in the non-standard gcc-toolset-14 path.
+# Create the missing symlink so the hermetic linker can find it.
+RUN ln -sf /usr/lib64/libstdc++.so.6 /usr/lib64/libstdc++.so
+
 # Use the symlinked Python to bootstrap pip and install the auditwheel
 # package. This is required for the JAX CI scripts.
 RUN python -m ensurepip && python -m pip install auditwheel


### PR DESCRIPTION
## Motivation

Yesterday upstream CI fails with:
```
jax.errors.JaxRuntimeError: NOT_FOUND: No FFI handler registered for hipsolver_gesvdj_ffi on a platform ROCM (canonical rocm)
```
While today another set of patches for the hermetic build landed, that breaks the CI build upstream.

The last issue being the manylinux container including only `/usr/lib64/libstdc++.so.6` while the hermetic build without the  hermetic sysroot tries to link against `libstdc++.so` that is missing. This PR addresses both.

## Technical Details

Inspecting the plugin wheel produced by the CI, the first symptom is that the `_solver.so` library links to `librocsolver.so.1` instead of `librocsolver.so.0`.

Wheels build on the dev or base containers do not have the issue. Contrarily, wheels built using the hermetic build on the `manylinux` container reproduce the issue from the upstream CI.

Carefully inspecting the build logs:
```
2026-05-19 02:11:42,670 - INFO - WARNING: The following configs were expanded more than once: [rocm_base, clang_local, rocm]. For repeatable flags, repeats are counted twice and may lead to unexpected behavior.
2026-05-19 02:11:42,728 - INFO - DEBUG: /home/jaxdev/.cache/bazel/_bazel_jaxdev/b860e094c613993117be5a7dd86f69ad/external/rules_ml_toolchain/gpu/rocm/hipcc_configure.bzl:181:10: Downloading https://repo.amd.com/rocm/tarball/therock-dist-linux-gfx908-7.12.0.tar.gz
```

The root cause is that `rules_ml_toolchain/gpu/rocm/hipcc_configure.bzl` relies on the `ROCM_PATH` environment variable to be set in order to use the local ROCm installation. Unfortunately, the `manylinux` container did not have that set and the hermetic build logic defaults to downloading that pinned version of TheROCk.

## Test Plan

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
