### PR TITLE
Use all known TheRock target families in RUNPATH so that our wheels find host theRock .so file libs path

### DIFF
--- a/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
@@ -211,6 +211,28 @@ def get_jax_commit_hash():
     return args.jax_commit
 
 
+# Every known TheRock target family. Each user installs one of the matching
+# rocm-sdk-libraries-<family> wheels for their GPU; the loader silently skips
+# the entries whose dirs don't exist in site-packages.
+_THEROCK_TARGET_FAMILIES = (
+    "gfx950-dcgpu",
+    "gfx94X-dcgpu",
+    "gfx90a",
+    "gfx90X-dcgpu",
+    "gfx908",
+    "gfx906",
+    "gfx900",
+    "gfx120X-all",
+    "gfx1153",
+    "gfx1152",
+    "gfx1151",
+    "gfx1150",
+    "gfx110X-all",
+    "gfx103X-all",
+    "gfx101X-dgpu",
+)
+
+
 def prepare_wheel_rocm(wheel_sources_path: pathlib.Path, *, cpu, rocm_version, srcs):
     # pylint: disable=too-many-locals
     """Assembles a source tree for the rocm kernel wheel in `sources_path`."""
@@ -285,16 +307,20 @@ def prepare_wheel_rocm(wheel_sources_path: pathlib.Path, *, cpu, rocm_version, s
         f"_triton.{pyext}",
         f"rocm_plugin_extension.{pyext}",
     ]
-    runpath = ":".join(
-        [
-            "$ORIGIN/../rocm/lib",
-            "$ORIGIN/../rocm/lib/rocm_sysdeps/lib",
-            "$ORIGIN/../../rocm/lib",
-            "$ORIGIN/../../rocm/lib/rocm_sysdeps/lib",
-            "/opt/rocm/lib",
-            "/opt/rocm/lib/rocm_sysdeps/lib",
-        ]
-    )
+    # TheRock: libs live under site-packages/_rocm_sdk_{core,libraries_<family>}/lib.
+    runpath_entries = [
+        "$ORIGIN/../_rocm_sdk_core/lib",
+        "$ORIGIN/../../_rocm_sdk_core/lib",
+        "$ORIGIN/../_rocm_sdk_core/lib/rocm_sysdeps/lib",
+        "$ORIGIN/../../_rocm_sdk_core/lib/rocm_sysdeps/lib",
+    ]
+    for family in _THEROCK_TARGET_FAMILIES:
+        family_dir = "_rocm_sdk_libraries_" + family.replace("-", "_")
+        runpath_entries.append(f"$ORIGIN/../{family_dir}/lib")
+        runpath_entries.append(f"$ORIGIN/../../{family_dir}/lib")
+    # Legacy ROCm: flat /opt/rocm/lib install.
+    runpath_entries.append("/opt/rocm/lib")
+    runpath = ":".join(runpath_entries)
     # patchelf --set-rpath $RUNPATH $so
     for f in files:
         so_path = os.path.join(plugin_dir, f)

--- a/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
+++ b/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
@@ -194,6 +194,28 @@ def get_jax_commit_hash():
     return args.jax_commit
 
 
+# Every known TheRock target family. Each user installs one of the matching
+# rocm-sdk-libraries-<family> wheels for their GPU; the loader silently skips
+# the entries whose dirs don't exist in site-packages.
+_THEROCK_TARGET_FAMILIES = (
+    "gfx950-dcgpu",
+    "gfx94X-dcgpu",
+    "gfx90a",
+    "gfx90X-dcgpu",
+    "gfx908",
+    "gfx906",
+    "gfx900",
+    "gfx120X-all",
+    "gfx1153",
+    "gfx1152",
+    "gfx1151",
+    "gfx1150",
+    "gfx110X-all",
+    "gfx103X-all",
+    "gfx101X-dgpu",
+)
+
+
 def prepare_rocm_plugin_wheel(
     wheel_sources_path: pathlib.Path, *, cpu, rocm_version, srcs
 ):
@@ -223,10 +245,11 @@ def prepare_rocm_plugin_wheel(
 
     build_utils.update_setup_with_rocm_version(wheel_sources_path, rocm_version)
     write_setup_cfg(wheel_sources_path, cpu)
-    xla_commit_hash = get_xla_commit_hash()
-    jax_commit_hash = get_jax_commit_hash()
     build_utils.write_commit_info(
-        plugin_dir, xla_commit_hash, jax_commit_hash, get_rocm_jax_git_hash()
+        plugin_dir,
+        get_xla_commit_hash(),
+        get_jax_commit_hash(),
+        get_rocm_jax_git_hash(),
     )
 
     # NOTE(mrodden): this is a hack to change/set rpath values
@@ -247,16 +270,20 @@ def prepare_rocm_plugin_wheel(
         raise RuntimeError(mesg) from ex
 
     shared_obj_path = os.path.join(plugin_dir, "xla_rocm_plugin.so")
-    runpath = ":".join(
-        [
-            "$ORIGIN/../rocm/lib",
-            "$ORIGIN/../rocm/lib/rocm_sysdeps/lib",
-            "$ORIGIN/../../rocm/lib",
-            "$ORIGIN/../../rocm/lib/rocm_sysdeps/lib",
-            "/opt/rocm/lib",
-            "/opt/rocm/lib/rocm_sysdeps/lib",
-        ]
-    )
+    # TheRock: libs live under site-packages/_rocm_sdk_{core,libraries_<family>}/lib.
+    runpath_entries = [
+        "$ORIGIN/../_rocm_sdk_core/lib",
+        "$ORIGIN/../../_rocm_sdk_core/lib",
+        "$ORIGIN/../_rocm_sdk_core/lib/rocm_sysdeps/lib",
+        "$ORIGIN/../../_rocm_sdk_core/lib/rocm_sysdeps/lib",
+    ]
+    for family in _THEROCK_TARGET_FAMILIES:
+        family_dir = "_rocm_sdk_libraries_" + family.replace("-", "_")
+        runpath_entries.append(f"$ORIGIN/../{family_dir}/lib")
+        runpath_entries.append(f"$ORIGIN/../../{family_dir}/lib")
+    # Legacy ROCm: flat /opt/rocm/lib install.
+    runpath_entries.append("/opt/rocm/lib")
+    runpath = ":".join(runpath_entries)
     # patchelf --set-rpath $RUNPATH $so
     fix_perms = False
     perms = os.stat(shared_obj_path).st_mode


### PR DESCRIPTION
## Motivation

The previous RPATH implementation required ROCM_SDK_TARGET_FAMILY to be set at build time, tying each built wheel to a single TheRock target family. Users installing rocm-sdk-libraries-gfx94X-dcgpu on a wheel built with gfx950-dcgpu would fail to resolve math libraries like libhipblas.so.3 and libMIOpen.so.1.

## Technical Details

* Replaced the ROCM_SDK_TARGET_FAMILY-driven single-family RUNPATH lookup with a hardcoded _THEROCK_TARGET_FAMILIES tuple listing all 15 known TheRock families (gfx950-dcgpu through gfx101X-dgpu) in both build_gpu_kernels_wheel.py and build_gpu_plugin_wheel.py.
* RUNPATH now unconditionally includes \$ORIGIN/{..,../..}/_rocm_sdk_libraries_/lib for every family. The dynamic loader silently skips entries whose dirs don't exist, so only the user's installed family is actually searched.
* Removed _get_rocm_sdk_target_family() and the regex parsing from build/ci_build; removed -e ROCM_SDK_TARGET_FAMILY=... forwarding from jax_rocm_plugin/build/rocm/ci_build. No build-time target family input is required anymore.

## Test Plan

* readelf -d + ldd on the installed .sos in TheRock and legacy containers.
* Full ci/run_pytest_rocm.sh on MI350 (gfx950-dcgpu) and MI300X (gfx94X-dcgpu) using the same wheel built from the gfx950-dcgpu TheRock index, plus legacy /opt/rocm-7.2.0.

## Submission Checklist
* Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.