### PR TITLE
Bump ROCm/jax pin to rocm-jaxlib-v0.9.2 tip (e858823873)

### DIFF
--- a/jax_rocm_plugin/third_party/jax/workspace.bzl
+++ b/jax_rocm_plugin/third_party/jax/workspace.bzl
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 #   1. Find the commit hash you want to pin to (e.g., from rocm-jaxlib-v0.9.2 branch)
 #   2. Update JAX_COMMIT below
 
-JAX_COMMIT = "877480e397c0177685a53d313b456588d4f57638"
+JAX_COMMIT = "e858823873a87b02e3e551223985c7b63dad4d58"
 
 def repo():
     git_repository(


### PR DESCRIPTION
## Summary

Bumps the `JAX_COMMIT` pin in `jax_rocm_plugin/third_party/jax/workspace.bzl` from `877480e397` to `e858823873` (current tip of ROCm/jax `rocm-jaxlib-v0.9.2`).

## Commits pulled in

- [`2b211b8f52`](https://github.com/ROCm/jax/commit/2b211b8f52) — [v0.9.2] Remove outdated ROCm skip that depends on ROCm versions < 6.4 (ROCm/jax#779)
- [`e858823873`](https://github.com/ROCm/jax/commit/e858823873) — Remove stale xla_gpu_cublaslt_algorithm3.patch to fix v0.9.2 build (ROCm/jax#778)

## Submission Checklist
* Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.