### PR TITLE
Remove sysdeps entries from rpath and Update XLA hash

### DIFF
--- a/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
@@ -257,18 +257,16 @@ def prepare_wheel_rocm(wheel_sources_path: pathlib.Path, *, cpu, rocm_version, s
         f"_triton.{pyext}",
         f"rocm_plugin_extension.{pyext}",
     ]
-    # TheRock: libs live under site-packages/_rocm_sdk_{core,libraries_<family>}/lib.
+    # TheRock (pip wheels): libs under site-packages/_rocm_sdk_{core,libraries_<family>}/lib.
     runpath_entries = [
         "$ORIGIN/../_rocm_sdk_core/lib",
         "$ORIGIN/../../_rocm_sdk_core/lib",
-        "$ORIGIN/../_rocm_sdk_core/lib/rocm_sysdeps/lib",
-        "$ORIGIN/../../_rocm_sdk_core/lib/rocm_sysdeps/lib",
     ]
     for family in _THEROCK_TARGET_FAMILIES:
         family_dir = "_rocm_sdk_libraries_" + family.replace("-", "_")
         runpath_entries.append(f"$ORIGIN/../{family_dir}/lib")
         runpath_entries.append(f"$ORIGIN/../../{family_dir}/lib")
-    # Legacy ROCm: flat /opt/rocm/lib install.
+    # Legacy ROCm / TheRock tarball extracted to /opt/rocm.
     runpath_entries.append("/opt/rocm/lib")
     runpath = ":".join(runpath_entries)
     # patchelf --set-rpath $RUNPATH $so

--- a/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
+++ b/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
@@ -234,18 +234,16 @@ def prepare_rocm_plugin_wheel(
         raise RuntimeError(mesg) from ex
 
     shared_obj_path = os.path.join(plugin_dir, "xla_rocm_plugin.so")
-    # TheRock: libs live under site-packages/_rocm_sdk_{core,libraries_<family>}/lib.
+    # TheRock (pip wheels): libs under site-packages/_rocm_sdk_{core,libraries_<family>}/lib.
     runpath_entries = [
         "$ORIGIN/../_rocm_sdk_core/lib",
         "$ORIGIN/../../_rocm_sdk_core/lib",
-        "$ORIGIN/../_rocm_sdk_core/lib/rocm_sysdeps/lib",
-        "$ORIGIN/../../_rocm_sdk_core/lib/rocm_sysdeps/lib",
     ]
     for family in _THEROCK_TARGET_FAMILIES:
         family_dir = "_rocm_sdk_libraries_" + family.replace("-", "_")
         runpath_entries.append(f"$ORIGIN/../{family_dir}/lib")
         runpath_entries.append(f"$ORIGIN/../../{family_dir}/lib")
-    # Legacy ROCm: flat /opt/rocm/lib install.
+    # Legacy ROCm / TheRock tarball extracted to /opt/rocm.
     runpath_entries.append("/opt/rocm/lib")
     runpath = ":".join(runpath_entries)
     # patchelf --set-rpath $RUNPATH $so

--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -13,7 +13,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 #   1. Find the commit hash you want to pin to (e.g., from rocm-jaxlib-v0.9.1 branch)
 #   2. Update XLA_COMMIT below
 
-XLA_COMMIT = "b32df5f07315567cc1940388ef766b87c6e8b9e3"
+XLA_COMMIT = "28d1cbc3e4b3305202ab297674682839f35df9a9"
 
 def repo():
     git_repository(


### PR DESCRIPTION
## Motivation

PR #438 removed /opt/rocm/lib/rocm_sysdeps/lib from the wheel RUNPATH, breaking TheRock CI where ROCm is installed via tarball extraction to /opt/rocm. The librocm_sysdeps_*.so.1 libraries live at /opt/rocm/lib/rocm_sysdeps/lib/ in that layout and could no longer be found.

## Technical Details

Added /opt/rocm/lib/rocm_sysdeps/lib back to the RUNPATH in both build_gpu_kernels_wheel.py and build_gpu_plugin_wheel.py, alongside the existing /opt/rocm/lib entry. This covers TheRock tarball installs (extracted to /opt/rocm-<ver>, symlinked to /opt/rocm) and the three ROCm install methods: pip wheels, tarballs, and system packages (deb/rpm).

Fixes https://github.com/ROCm/TheRock/issues/5369.

## Test Plan

Verify ldd resolves all deps when ROCm is installed via tarball at /opt/rocm.

## Test Result

readelf -d confirms /opt/rocm/lib/rocm_sysdeps/lib is present in the patched .so RUNPATH.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
