### PR TITLE
Add pinned TheRock version slug for 7.13.

### DIFF
--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -121,6 +121,7 @@ jobs:
       fail-fast: false
       matrix:
         install-llvm: [true, false]
+        therock-version: ["", "7.13.0a20260515"]
         include:
           - runner-label: "linux-x86-64-1gpu-amd"
             therock-index-url: "https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/"
@@ -188,6 +189,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        therock-version: ["", "7.13.0a20260515"]
         include:
           - therock-index-url: >-
               https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/


### PR DESCRIPTION
## Motivation
This PR adds a pinned TheRock version slug for 7.13. This allows for the creation of a TheRock image with a pinned 7.13 installation alongside an image with the latest version.

The pinned version will allow us to have a separate building and testing image for the release process.

## Changes 
Changes are contained to adding a 7.13 version slug to `.github/workflows/build-base-docker.yml`
