### PR TITLE
[CI] Add TheRock 7.13 support and retire ROCm 7.1.1

### DIFF
--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -5,6 +5,12 @@ on:
     # Run every Sunday at midnight UTC
     - cron: '0 0 * * 0'
   workflow_dispatch:
+    inputs:
+      push-latest-tag:
+        description: "Push :latest to ghcr.io; enable only for intentional CI image updates"
+        required: false
+        type: boolean
+        default: false
   pull_request:
     paths:
       - 'build/ci_build'
@@ -26,11 +32,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rocm-version: ["7.1.1", "7.2.0"]
+        rocm-version: ["7.2.0"]
         install-llvm: [true, false]
         include:
-          - rocm-version: "7.1.1"
-            runner-label: "linux-x86-64-1gpu-amd"
           - rocm-version: "7.2.0"
             runner-label: "linux-x86-64-1gpu-amd"
     steps:
@@ -98,7 +102,10 @@ jobs:
           docker tag "${image_tag}" "${ghcr_image_sha}"
           docker push "${ghcr_image_sha}"
       - name: Push latest tag
-        if: github.event_name != 'pull_request'
+        if: >-
+          github.event_name != 'pull_request' &&
+          (github.event_name != 'workflow_dispatch' ||
+          inputs.push-latest-tag == true)
         env:
           ROCM_VERSION: ${{ matrix.rocm-version }}
           INSTALL_LLVM: ${{ matrix.install-llvm }}
@@ -123,7 +130,10 @@ jobs:
         install-llvm: [true, false]
         include:
           - runner-label: "linux-x86-64-1gpu-amd"
-            therock-index-url: "https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/"
+            therock-index-url: "https://rocm.nightlies.amd.com/whl-multi-arch/"
+          - runner-label: "linux-x86-64-1gpu-amd"
+            therock-index-url: "https://repo.amd.com/rocm/whl-multi-arch/"
+            therock-version: "7.13.0"
     steps:
       - name: Clean up old runs
         run: |
@@ -170,18 +180,39 @@ jobs:
           else
             image_tag="jax-base-ubu24.therock-${ver_slug}"
           fi
+          ghcr_base="ghcr.io/rocm/${image_tag}"
 
-          # Push with commit SHA tag
-          ghcr_image_sha="ghcr.io/rocm/${image_tag}:${GITHUB_SHA}"
-          echo "Image name (SHA): ${ghcr_image_sha}"
-          docker tag "${image_tag}" "${ghcr_image_sha}"
-          docker push "${ghcr_image_sha}"
+          # Always push SHA tag
+          echo "Image name (SHA): ${ghcr_base}:${GITHUB_SHA}"
+          docker tag "${image_tag}" "${ghcr_base}:${GITHUB_SHA}"
+          docker push "${ghcr_base}:${GITHUB_SHA}"
 
-          # Push with latest tag
-          ghcr_image_latest="ghcr.io/rocm/${image_tag}:latest"
-          echo "Image name (latest): ${ghcr_image_latest}"
-          docker tag "${image_tag}" "${ghcr_image_latest}"
-          docker push "${ghcr_image_latest}"
+          # Push version tag when pinned (stable reference for downstream CI)
+          if [ -n "${THEROCK_VERSION}" ]; then
+            echo "Image name (version): ${ghcr_base}:${THEROCK_VERSION}"
+            docker tag "${image_tag}" "${ghcr_base}:${THEROCK_VERSION}"
+            docker push "${ghcr_base}:${THEROCK_VERSION}"
+          fi
+      - name: Push latest tag
+        if: >-
+          github.event_name != 'pull_request' &&
+          (github.event_name != 'workflow_dispatch' ||
+          inputs.push-latest-tag == true)
+        env:
+          INSTALL_LLVM: ${{ matrix.install-llvm }}
+          THEROCK_VERSION: ${{ matrix.therock-version }}
+        run: |
+          ver_slug="${THEROCK_VERSION:-latest}"
+          if [ "$INSTALL_LLVM" = "true" ]; then
+            image_tag="jax-dev-ubu24.therock-${ver_slug}"
+          else
+            image_tag="jax-base-ubu24.therock-${ver_slug}"
+          fi
+          ghcr_base="ghcr.io/rocm/${image_tag}"
+
+          echo "Image name (latest): ${ghcr_base}:latest"
+          docker tag "${image_tag}" "${ghcr_base}:latest"
+          docker push "${ghcr_base}:latest"
 
   build-therock-manylinux-images:
     runs-on: linux-x86-64-1gpu-amd
@@ -190,7 +221,9 @@ jobs:
       matrix:
         include:
           - therock-index-url: >-
-              https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/
+              https://rocm.nightlies.amd.com/whl-multi-arch/
+          - therock-index-url: "https://repo.amd.com/rocm/whl-multi-arch/"
+            therock-version: "7.13.0"
     steps:
       - name: Clean up old runs
         run: |
@@ -235,28 +268,42 @@ jobs:
         run: |
           ver_slug="${THEROCK_VERSION:-latest}"
           image_tag="jax-manylinux_2_28-therock-${ver_slug}"
+          ghcr_base="ghcr.io/rocm/${image_tag}"
 
-          # Push with commit SHA tag
-          ghcr_sha="ghcr.io/rocm/${image_tag}:${GITHUB_SHA}"
-          echo "Image name (SHA): ${ghcr_sha}"
-          docker tag "${image_tag}" "${ghcr_sha}"
-          docker push "${ghcr_sha}"
+          # Always push SHA tag
+          echo "Image name (SHA): ${ghcr_base}:${GITHUB_SHA}"
+          docker tag "${image_tag}" "${ghcr_base}:${GITHUB_SHA}"
+          docker push "${ghcr_base}:${GITHUB_SHA}"
 
-          # Push with latest tag
-          ghcr_latest="ghcr.io/rocm/${image_tag}:latest"
-          echo "Image name (latest): ${ghcr_latest}"
-          docker tag "${image_tag}" "${ghcr_latest}"
-          docker push "${ghcr_latest}"
+          # Push version tag when pinned (stable reference for downstream CI)
+          if [ -n "${THEROCK_VERSION}" ]; then
+            echo "Image name (version): ${ghcr_base}:${THEROCK_VERSION}"
+            docker tag "${image_tag}" "${ghcr_base}:${THEROCK_VERSION}"
+            docker push "${ghcr_base}:${THEROCK_VERSION}"
+          fi
+      - name: Push latest tag
+        if: >-
+          github.event_name != 'pull_request' &&
+          (github.event_name != 'workflow_dispatch' ||
+          inputs.push-latest-tag == true)
+        env:
+          THEROCK_VERSION: ${{ matrix.therock-version }}
+        run: |
+          ver_slug="${THEROCK_VERSION:-latest}"
+          image_tag="jax-manylinux_2_28-therock-${ver_slug}"
+          ghcr_base="ghcr.io/rocm/${image_tag}"
+
+          echo "Image name (latest): ${ghcr_base}:latest"
+          docker tag "${image_tag}" "${ghcr_base}:latest"
+          docker push "${ghcr_base}:latest"
 
   build-manylinux-builder-images:
     runs-on: ${{ matrix.runner-label }}
     strategy:
       fail-fast: false
       matrix:
-        rocm-version: ["7.1.1", "7.2.0"]
+        rocm-version: ["7.2.0"]
         include:
-          - rocm-version: "7.1.1"
-            runner-label: "linux-x86-64-1gpu-amd"
           - rocm-version: "7.2.0"
             runner-label: "linux-x86-64-1gpu-amd"
     steps:
@@ -304,7 +351,10 @@ jobs:
           docker tag "${image_tag}" "${sha_image_tag}"
           docker push "${sha_image_tag}"
       - name: Push latest tag
-        if: github.event_name != 'pull_request'
+        if: >-
+          github.event_name != 'pull_request' &&
+          (github.event_name != 'workflow_dispatch' ||
+          inputs.push-latest-tag == true)
         env:
           ROCM_VERSION: ${{ matrix.rocm-version }}
           ROCM_BUILD_JOB: >-

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,10 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rocm-version: ["7.1.1", "7.2.0"]
+        rocm-version: ["7.2.0"]
         include:
-          - rocm-version: "7.1.1"
-            runner-label: '["linux-x86-64-1gpu-amd"]'
           - rocm-version: "7.2.0"
             runner-label: '["linux-x86-64-1gpu-amd"]'
     uses: ./.github/workflows/build-wheels.yml
@@ -43,10 +41,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rocm-version: ["7.1.1", "7.2.0"]
+        rocm-version: ["7.2.0"]
         include:
-          - rocm-version: "7.1.1"
-            runner-label: '["linux-x86-64-1gpu-amd"]'
           - rocm-version: "7.2.0"
             runner-label: '["linux-x86-64-1gpu-amd"]'
     uses: ./.github/workflows/build-docker.yml

--- a/docker/Dockerfile.base-therock-ubu24
+++ b/docker/Dockerfile.base-therock-ubu24
@@ -49,7 +49,7 @@ RUN apt-get update && \
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     python3 -m pip install --break-system-packages \
         --pre --index-url "${THEROCK_INDEX_URL}" \
-        "rocm[libraries,devel]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
+        "rocm[libraries,devel,device-gfx950]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
     rocm-sdk init && \
     ln -sfn "$(rocm-sdk path --root)" /opt/rocm
 

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     /opt/python/cp312-cp312/bin/python3 -m pip install \
         --pre --index-url "${THEROCK_INDEX_URL}" \
-        "rocm[libraries,devel]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
+        "rocm[libraries,devel,device-gfx950]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
     ln -sf /opt/python/cp312-cp312/bin/rocm-sdk /usr/local/bin/rocm-sdk && \
     rocm-sdk init && \
     ln -sfn "$(rocm-sdk path --root)" /opt/rocm


### PR DESCRIPTION
## Summary

Extends the container build CI to support TheRock 7.13 (pinned to `7.13.0a20260515`) alongside the existing TheRock latest (rolling nightly) variant, and retires ROCm 7.1.1 which is superseded by 7.2.0.

**Why TheRock for 7.13?** ROCm 7.13 is distributed exclusively via the TheRock pip-based path (`rocm.nightlies.amd.com/whl-multi-arch`); no traditional deb/tarball packages exist for this version.

## Changes

### `build-base-docker.yml`
- Add `therock-version: "7.13.0a20260515"` matrix include to both `build-therock-base-images` and `build-therock-manylinux-images` jobs. Produces the following new images:
  - `ghcr.io/rocm/jax-base-ubu24.therock-7.13.0a20260515:latest`
  - `ghcr.io/rocm/jax-dev-ubu24.therock-7.13.0a20260515:latest`
  - `ghcr.io/rocm/jax-manylinux_2_28-therock-7.13.0a20260515:latest`
- Remove ROCm 7.1.1 from `build-base-images` and `build-manylinux-builder-images` matrices.
- Add `push-latest-tag` boolean `workflow_dispatch` input (default: `false`). Manual runs no longer silently overwrite the `:latest` tags consumed by upstream JAX CI. Scheduled (`cron`) and `push`-triggered runs continue to push `:latest` unconditionally, preserving existing automation behavior.

### `nightly.yml`
- Remove ROCm 7.1.1 from both `call-build-wheels` and `call-build-docker` matrices.
