### PR TITLE
[Cherry-pick] Remove rocm_sysdeps from runpath entries (from #444)

### DIFF
--- a/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
@@ -307,18 +307,16 @@ def prepare_wheel_rocm(wheel_sources_path: pathlib.Path, *, cpu, rocm_version, s
         f"_triton.{pyext}",
         f"rocm_plugin_extension.{pyext}",
     ]
-    # TheRock: libs live under site-packages/_rocm_sdk_{core,libraries_<family>}/lib.
+    # TheRock (pip wheels): libs under site-packages/_rocm_sdk_{core,libraries_<family>}/lib.
     runpath_entries = [
         "$ORIGIN/../_rocm_sdk_core/lib",
         "$ORIGIN/../../_rocm_sdk_core/lib",
-        "$ORIGIN/../_rocm_sdk_core/lib/rocm_sysdeps/lib",
-        "$ORIGIN/../../_rocm_sdk_core/lib/rocm_sysdeps/lib",
     ]
     for family in _THEROCK_TARGET_FAMILIES:
         family_dir = "_rocm_sdk_libraries_" + family.replace("-", "_")
         runpath_entries.append(f"$ORIGIN/../{family_dir}/lib")
         runpath_entries.append(f"$ORIGIN/../../{family_dir}/lib")
-    # Legacy ROCm: flat /opt/rocm/lib install.
+    # Legacy ROCm / TheRock tarball extracted to /opt/rocm.
     runpath_entries.append("/opt/rocm/lib")
     runpath = ":".join(runpath_entries)
     # patchelf --set-rpath $RUNPATH $so

--- a/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
+++ b/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
@@ -270,18 +270,16 @@ def prepare_rocm_plugin_wheel(
         raise RuntimeError(mesg) from ex
 
     shared_obj_path = os.path.join(plugin_dir, "xla_rocm_plugin.so")
-    # TheRock: libs live under site-packages/_rocm_sdk_{core,libraries_<family>}/lib.
+    # TheRock (pip wheels): libs under site-packages/_rocm_sdk_{core,libraries_<family>}/lib.
     runpath_entries = [
         "$ORIGIN/../_rocm_sdk_core/lib",
         "$ORIGIN/../../_rocm_sdk_core/lib",
-        "$ORIGIN/../_rocm_sdk_core/lib/rocm_sysdeps/lib",
-        "$ORIGIN/../../_rocm_sdk_core/lib/rocm_sysdeps/lib",
     ]
     for family in _THEROCK_TARGET_FAMILIES:
         family_dir = "_rocm_sdk_libraries_" + family.replace("-", "_")
         runpath_entries.append(f"$ORIGIN/../{family_dir}/lib")
         runpath_entries.append(f"$ORIGIN/../../{family_dir}/lib")
-    # Legacy ROCm: flat /opt/rocm/lib install.
+    # Legacy ROCm / TheRock tarball extracted to /opt/rocm.
     runpath_entries.append("/opt/rocm/lib")
     runpath = ":".join(runpath_entries)
     # patchelf --set-rpath $RUNPATH $so

--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -13,7 +13,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 #   1. Find the commit hash you want to pin to (e.g., from rocm-jaxlib-v0.9.2 branch)
 #   2. Update XLA_COMMIT below
 
-XLA_COMMIT = "d8b2a5f5ece8af6b45e0fbfd6d3dbea1958d2f7e"
+XLA_COMMIT = "f7d005c57fcaac805e79f911153ab748e73f0fa6"
 
 def repo():
     git_repository(


### PR DESCRIPTION
## Motivation

Cherry-pick of the first commit of ROCm/rocm-jax#444 (`9f0556f27`) from `rocm-jaxlib-v0.9.1` to `rocm-jaxlib-v0.9.2`. The XLA-hash-update commit from #444 is intentionally excluded — that bump is specific to v0.9.1's XLA pin.

Per #444's motivation: #438 removed `/opt/rocm/lib/rocm_sysdeps/lib` from the wheel RUNPATH, then #440/#442 (already on v0.9.2) added `_rocm_sdk_libraries_<family>/lib` entries. This commit completes that work on v0.9.2 by also removing the now-redundant `_rocm_sdk_core/lib/rocm_sysdeps/lib` runpath entries — TheRock tarball installs under `/opt/rocm` are covered by the existing `/opt/rocm/lib` entry, and TheRock pip wheels are covered by the per-family entries.
