### PR TITLE
[CI] Fix TheRock matrix to build all variants with and without LLVM

### DIFF
--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -28,6 +28,9 @@ on:
 
 jobs:
   build-base-images:
+    name: >-
+      ROCm ${{ matrix.rocm-version }},
+      ${{ matrix.install-llvm && 'with' || 'without' }} LLVM
     runs-on: ${{ matrix.runner-label }}
     strategy:
       fail-fast: false
@@ -123,17 +126,21 @@ jobs:
           docker push "${ghcr_image_latest}"
 
   build-therock-base-images:
+    name: >-
+      TheRock ${{ matrix.therock-version || 'latest' }},
+      ${{ matrix.install-llvm && 'with' || 'without' }} LLVM
     runs-on: ${{ matrix.runner-label }}
     strategy:
       fail-fast: false
       matrix:
         install-llvm: [true, false]
+        therock-version: ["", "7.13.0"]
         include:
           - runner-label: "linux-x86-64-1gpu-amd"
+          - therock-version: ""
             therock-index-url: "https://rocm.nightlies.amd.com/whl-multi-arch/"
-          - runner-label: "linux-x86-64-1gpu-amd"
+          - therock-version: "7.13.0"
             therock-index-url: "https://repo.amd.com/rocm/whl-multi-arch/"
-            therock-version: "7.13.0"
     steps:
       - name: Clean up old runs
         run: |
@@ -215,15 +222,17 @@ jobs:
           docker push "${ghcr_base}:latest"
 
   build-therock-manylinux-images:
+    name: "TheRock ${{ matrix.therock-version || 'latest' }}, manylinux"
     runs-on: linux-x86-64-1gpu-amd
     strategy:
       fail-fast: false
       matrix:
+        therock-version: ["", "7.13.0"]
         include:
-          - therock-index-url: >-
-              https://rocm.nightlies.amd.com/whl-multi-arch/
-          - therock-index-url: "https://repo.amd.com/rocm/whl-multi-arch/"
-            therock-version: "7.13.0"
+          - therock-version: ""
+            therock-index-url: "https://rocm.nightlies.amd.com/whl-multi-arch/"
+          - therock-version: "7.13.0"
+            therock-index-url: "https://repo.amd.com/rocm/whl-multi-arch/"
     steps:
       - name: Clean up old runs
         run: |
@@ -298,6 +307,7 @@ jobs:
           docker push "${ghcr_base}:latest"
 
   build-manylinux-builder-images:
+    name: "ROCm ${{ matrix.rocm-version }}, manylinux"
     runs-on: ${{ matrix.runner-label }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Fixes a matrix configuration bug introduced in #446 where `therock-latest` images were not being built with both `install-llvm: true` and `install-llvm: false` variants.

## Problem

Using `include`-only to specify the two TheRock index URLs caused GitHub Actions to treat each entry as a standalone combination rather than cross-multiplying them with the `install-llvm: [true, false]` dimension. As a result, `therock-latest` images were not produced from the `build-therock-base-images` job.

## Fix

Promote `therock-version` to a proper matrix dimension (`["", "7.13.0"]`, where `""` represents the rolling nightly), and attach the corresponding `therock-index-url` to each value via `include` matching. This keeps the semantic relationship explicit without using the registry URL as a proxy for the version.

The resulting matrix for `build-therock-base-images` is a clean 2×2 cross-product:

| `therock-version` | `install-llvm` | `therock-index-url` |
|---|---|---|
| `""` (latest) | true | rocm.nightlies.amd.com |
| `""` (latest) | false | rocm.nightlies.amd.com |
| `7.13.0` | true | repo.amd.com |
| `7.13.0` | false | repo.amd.com |

## Test plan

- [x] Verify the `Build Base Docker Images` workflow shows 4 jobs for `build-therock-base-images` and 2 for `build-therock-manylinux-images`.
- [x] Confirm `jax-base-ubu24.therock-latest` and `jax-dev-ubu24.therock-latest` images are produced alongside their `therock-7.13.0` counterparts.