### PR TITLE
[TheRock] Align manylinux Dockerfile with ROCm counterpart

### DIFF
--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -47,6 +47,14 @@ RUN mkdir /tmp/llvm-project && \
 # Copy in our clang configuration file
 COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang++.cfg
 COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang.cfg
+COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang++.cfg
+COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang.cfg
+
+# ld.lld (hermetic linker) resolves -lstdc++ by looking for the unversioned
+# libstdc++.so in the sysroot. AlmaLinux 8 only ships libstdc++.so.6 in
+# /usr/lib64; the linker script lives in the non-standard gcc-toolset-14 path.
+# Create the missing symlink so the hermetic linker can find it.
+RUN ln -sf /usr/lib64/libstdc++.so.6 /usr/lib64/libstdc++.so
 
 # Install AWS CLI v2
 RUN --mount=type=cache,target=/var/cache/dnf \


### PR DESCRIPTION
## Summary

- Copy `clang.cfg` into `/opt/rocm/llvm/bin/` for both `clang` and `clang++`, mirroring what the ROCm Dockerfile already does for `/usr/lib/llvm-18/bin/`
- Add a symlink `libstdc++.so.6` → `libstdc++.so` so the hermetic `ld.lld` linker can resolve `-lstdc++` on AlmaLinux 8

Note: the TheRock Dockerfile already sets up an unversioned `python` symlink (pointing to `/opt/python/cp312-cp312/bin/python3`) and installs `auditwheel` earlier in the file, so those steps were not ported from the ROCm counterpart.

## Test plan

- [x] Verify the TheRock manylinux Docker image builds successfully
- [x] Verify JAX CI scripts run correctly inside the built image