### PR TITLE
Update XLA commit hash to bfbb0f4...

### DIFF
--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -13,7 +13,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 #   1. Find the commit hash you want to pin to (e.g., from rocm-jaxlib-v0.9.1 branch)
 #   2. Update XLA_COMMIT below
 
-XLA_COMMIT = "28d1cbc3e4b3305202ab297674682839f35df9a9"
+XLA_COMMIT = "bfbb0f4713969f129957c589a20c6b4493b7c67a"
 
 def repo():
     git_repository(


### PR DESCRIPTION
## Motivation

Update XLA commit hash to Restore LOG(WARNING)/LOG_FIRST_N for trace-event capacity limits (https://github.com/ROCm/xla/pull/874)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
