### PR TITLE
[manylinux] Bake GCC toolchain path into clang at build time

### DIFF
--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
@@ -20,14 +20,13 @@ RUN printf '%s\n' > /opt/rocm/bin/target.lst ${GPU_DEVICE_TARGETS}
 RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y wget && dnf clean all
 RUN mkdir /tmp/llvm-project && wget -qO - https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-18.1.8.tar.gz | tar -xz -C /tmp/llvm-project --strip-components 1 && \
-    mkdir /tmp/llvm-project/build && cd /tmp/llvm-project/build && cmake -DLLVM_ENABLE_PROJECTS='clang;lld' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-18/ ../llvm && \
+    mkdir /tmp/llvm-project/build && cd /tmp/llvm-project/build && \
+    cmake -DLLVM_ENABLE_PROJECTS='clang;lld' \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-18/ \
+          -DGCC_INSTALL_PREFIX=/opt/rh/gcc-toolset-14/root/usr \
+          ../llvm && \
     make -j$(nproc) && make -j$(nproc) install && rm -rf /tmp/llvm-project
-
-# Copy in our clang configuiration file
-COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang++.cfg
-COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang.cfg
-COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang++.cfg
-COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang.cfg
 
 # Install AWS CLI v2
 RUN --mount=type=cache,target=/var/cache/dnf \

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -39,16 +39,11 @@ RUN mkdir /tmp/llvm-project && \
     cmake -DLLVM_ENABLE_PROJECTS='clang;lld' \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-18/ \
+          -DGCC_INSTALL_PREFIX=/opt/rh/gcc-toolset-14/root/usr \
           ../llvm && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
     rm -rf /tmp/llvm-project
-
-# Copy in our clang configuration file
-COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang++.cfg
-COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang.cfg
-COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang++.cfg
-COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang.cfg
 
 # ld.lld (hermetic linker) resolves -lstdc++ by looking for the unversioned
 # libstdc++.so in the sysroot. AlmaLinux 8 only ships libstdc++.so.6 in

--- a/docker/manylinux/clang.cfg
+++ b/docker/manylinux/clang.cfg
@@ -1,2 +1,0 @@
-# tell clang where it can find gcc so that it can use gcc's standard libraries
---gcc-toolchain=/opt/rh/gcc-toolset-14/root/usr


### PR DESCRIPTION
## Summary

- Replace `docker/manylinux/clang.cfg` with `-DGCC_INSTALL_PREFIX=/opt/rh/gcc-toolset-14/root/usr` passed to cmake when building LLVM 18 from source in both manylinux Dockerfiles.
- Remove all four `COPY ./docker/manylinux/clang.cfg …` lines from `Dockerfile.jax-manylinux_2_28-rocm` and `Dockerfile.jax-manylinux_2_28-therock`.
- Delete `docker/manylinux/clang.cfg`.

The GCC toolchain path is now baked into the clang binary at compile time, eliminating the sidecar `.cfg` files that were causing hermetic build failures.

## Test plan

- [x] Build `Dockerfile.jax-manylinux_2_28-rocm` locally with `DOCKER_BUILDKIT=1 python3 build/ci_build --rocm-version=<ver> build_manylinux_dockers`
- [x] Build `Dockerfile.jax-manylinux_2_28-therock` locally with `DOCKER_BUILDKIT=1 python3 build/ci_build build_manylinux_therock_dockers`
- [x] Inside each container, verify: `/usr/lib/llvm-18/bin/clang -v 2>&1 | grep -i gcc` shows `Found GCC installation: /opt/rh/gcc-toolset-14/root/usr/...`
- [x] Confirm no `.cfg` files exist: `ls /usr/lib/llvm-18/bin/clang*.cfg` should fail
- [x] Run a hermetic JAX build inside the container and verify it succeeds