### PR TITLE
Remove /opt/rocm symlink from our theRock images

### DIFF
--- a/docker/Dockerfile.base-therock-ubu24
+++ b/docker/Dockerfile.base-therock-ubu24
@@ -44,18 +44,25 @@ RUN apt-get update && \
         zip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install TheRock (ROCm via pip), initialize the SDK, and create a
-# conventional /opt/rocm symlink so ENV directives use a known path.
+# Install TheRock (ROCm via pip) and initialize the SDK. Don't create a
+# /opt/rocm symlink: ROCm/jax PR #781's $ORIGIN-relative RUNPATHs resolve
+# ROCm libs from site-packages directly. Consumers that explicitly require
+# /opt/rocm should make the symlink at runtime, and set LD_LIBRARY_PATH
+# if their tooling needs it:
+#   ln -sfn "$(rocm-sdk path --root)" /opt/rocm
+#   export LD_LIBRARY_PATH=/opt/rocm/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     python3 -m pip install --break-system-packages \
         --pre --index-url "${THEROCK_INDEX_URL}" \
         "rocm[libraries,devel,device-gfx950]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
-    rocm-sdk init && \
-    ln -sfn "$(rocm-sdk path --root)" /opt/rocm
+    rocm-sdk init
 
 ENV ROCM_HOME=/opt/rocm
 ENV PATH="/opt/rocm/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/opt/rocm/lib"
+# Don't bake LD_LIBRARY_PATH=/opt/rocm/lib: on multi-arch installs that
+# routes libhipblaslt/librccl through _rocm_sdk_devel/lib, which is
+# missing per-arch device files (bridging gap). Leaving it unset lets
+# user-set LD_LIBRARY_PATH win and the wheel's RUNPATH otherwise.
 
 # Install GitHub CLI (gh):
 RUN --mount=type=cache,target=/var/cache/apt \


### PR DESCRIPTION
## Summary
Drop the `/opt/rocm` symlink creation in `docker/Dockerfile.base-therock-ubu24`. ROCm/jax wheels built with [PR #781](https://github.com/ROCm/jax/pull/781) bake `$ORIGIN`-relative `RUNPATH` entries into the rocm plugin/pjrt `.so` files, so ROCm libraries resolve from the Python site-packages tree (`<site-packages>/_rocm_sdk_*/lib/...`) without `/opt/rocm`. Skipping the symlink in the dev/test image makes wheel-test CI exercise the same `/opt/rocm`-free deployment that end users see, instead of validating against an artificially `/opt/rocm`-having container.

## Context
- The ROCm/jax wheel-test workflow [previously stripped `/opt/rocm` at job time](https://github.com/ROCm/jax/blob/therock-rpath-test-only/.github/workflows/pytest_rocm.yml#L167-L206) (TEST-ONLY commit kept for reference on the `therock-rpath-test-only` archive branch). With this Dockerfile change, that workflow-side strip becomes unnecessary — the dev image already lacks `/opt/rocm`, so the wheel test naturally validates `$ORIGIN`-relative resolution.
- The manylinux build image (`docker/manylinux/Dockerfile.jax-manylinux_2_28-therock`) **keeps** `/opt/rocm` because the wheel build still depends on `/opt/rocm/llvm/bin/clang++.cfg` (lines 50-51 of that Dockerfile).
- The three `ENV` lines (`ROCM_HOME`, `PATH`, `LD_LIBRARY_PATH`) that point at `/opt/rocm` are kept as-is; the dynamic linker silently skips non-existent paths so they're harmless. This mirrors the runtime strip step exactly, which also touched only the symlink.
## Known limitation
`librccl` calls `dlopen("libhsa-runtime64.so")` with the unversioned name. In TheRock multi-arch packaging, that alias only ships in `_rocm_sdk_devel/lib/`, so `librccl` can't find it once `/opt/rocm` is absent. RCCL collectives in this image will fail RCCL init with `Failed to find ROCm runtime library in (null) (RCCL_ROCR_PATH=(null))` until upstream [TheRock #5562](https://github.com/ROCm/TheRock/issues/5562) lands. Tracked separately; not addressed here.
Consumers that explicitly need `/opt/rocm` (e.g., debugging, third-party tools) can re-create the symlink at runtime:
```bash
ln -sfn "$(rocm-sdk path --root)" /opt/rocm
```
## Test Plan

- [x] CI rebuilds the dev/test images on this branch (jax-base-ubu24.therock-7.13.0:latest, jax-base-ubu24.therock-latest:latest).
- [x]  In the rebuilt container: ls -la /opt/rocm returns No such file or directory (confirms the symlink is gone).
- [x]  In the rebuilt container: rocm-sdk path --root returns a real _rocm_sdk_devel path (confirms rocm-sdk init still ran).
- [x]  Trigger ROCm/jax CI - Wheel Tests (Continuous) on therock-rpath (or any branch carrying [PR #781](https://github.com/ROCm/jax/pull/781)) using the new dev images. Pytest should:
  - [x] Successfully import JAX, register the rocm backend, return RocmDevices for all available GPUs.
  - [x] Pass single-GPU GEMM, hipBLASLt operations, and pmap-based multi-GPU tests that don't go through RCCL collectives (the RCCL collective tests will still fail until #5562 lands; document this in the PR comments if any reviewer flags it).
  - [x]  No regression on the apt-installed ROCm 7.2.0 dev image (this Dockerfile is TheRock-only).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
