### PR TITLE
[CI] Add image-set input to selectively build/repush base images

### DIFF
--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -11,6 +11,17 @@ on:
         required: false
         type: boolean
         default: false
+      image-set:
+        description: >-
+          Which image set to build/repush on manual dispatch: 'legacy'
+          (rocm720), 'therock', or 'both'. Scheduled/push/PR build all.
+        required: false
+        type: choice
+        options:
+          - therock
+          - legacy
+          - both
+        default: both
   pull_request:
     paths:
       - 'build/ci_build'
@@ -28,6 +39,13 @@ on:
 
 jobs:
   build-base-images:
+    # Legacy apt-ROCm (rocm720) base/dev images, shared with jax-ml/jax upstream
+    # (its pytest_rocm/bazel_rocm pin rocm-tag=rocm720). On manual dispatch only
+    # build when 'legacy' or 'both' is selected; scheduled/push/PR build all.
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.image-set == 'legacy' ||
+      inputs.image-set == 'both'
     name: >-
       ROCm ${{ matrix.rocm-version }},
       ${{ matrix.install-llvm && 'with' || 'without' }} LLVM
@@ -126,6 +144,12 @@ jobs:
           docker push "${ghcr_image_latest}"
 
   build-therock-base-images:
+    # TheRock base/dev images. On manual dispatch only build when 'therock' or
+    # 'both' is selected.
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.image-set == 'therock' ||
+      inputs.image-set == 'both'
     name: >-
       TheRock ${{ matrix.therock-version || 'latest' }},
       ${{ matrix.install-llvm && 'with' || 'without' }} LLVM
@@ -222,6 +246,11 @@ jobs:
           docker push "${ghcr_base}:latest"
 
   build-therock-manylinux-images:
+    # TheRock manylinux builder image. Part of the 'therock' set.
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.image-set == 'therock' ||
+      inputs.image-set == 'both'
     name: "TheRock ${{ matrix.therock-version || 'latest' }}, manylinux"
     runs-on: linux-x86-64-1gpu-amd
     strategy:
@@ -307,6 +336,11 @@ jobs:
           docker push "${ghcr_base}:latest"
 
   build-manylinux-builder-images:
+    # Legacy apt-ROCm 7.2.0 manylinux builder image. Part of the 'legacy' set.
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.image-set == 'legacy' ||
+      inputs.image-set == 'both'
     name: "ROCm ${{ matrix.rocm-version }}, manylinux"
     runs-on: ${{ matrix.runner-label }}
     strategy:


### PR DESCRIPTION
## Motivation

The workflow builds and pushes every image set in one run - the legacy apt-ROCm (rocm720) images and the TheRock images. The rocm720 images are shared with jax-ml/jax upstream (it pins rocm-tag: rocm720), so there's no way to refresh just the TheRock images without also repushing the upstream-shared ones. This adds per-set selection for manual runs.

## Technical Details

- Adds a workflow_dispatch input image-set (therock / legacy / both, default both).
- Gates each job: legacy jobs (build-base-images, build-manylinux-builder-images) run for legacy/both; TheRock jobs (build-therock-base-images, build-therock-manylinux-images) run for therock/both.
- Only narrows manual workflow_dispatch runs; scheduled/push/pull_request still build every set. Composes with push-latest-tag.

## Test Plan

- YAML parses; all four jobs carry the expected gate.
- On dispatch: therock runs only TheRock jobs, legacy only legacy jobs, both runs all four; non-dispatch runs build all.


## Test Result

Local YAML validation passed; gating confirmed on all four jobs. Dispatch include/skip behavior to confirm on first manual run post-merge.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
