### PR TITLE
Strip all env vars from TheRock dockerfiles

### DIFF
--- a/docker/Dockerfile.base-therock-ubu24
+++ b/docker/Dockerfile.base-therock-ubu24
@@ -46,23 +46,22 @@ RUN apt-get update && \
 
 # Install TheRock (ROCm via pip) and initialize the SDK. Don't create a
 # /opt/rocm symlink: ROCm/jax PR #781's $ORIGIN-relative RUNPATHs resolve
-# ROCm libs from site-packages directly. Consumers that explicitly require
-# /opt/rocm should make the symlink at runtime, and set LD_LIBRARY_PATH
-# if their tooling needs it:
-#   ln -sfn "$(rocm-sdk path --root)" /opt/rocm
-#   export LD_LIBRARY_PATH=/opt/rocm/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+# ROCm libs from site-packages directly (see the env note below for why we
+# also export no ROCm env vars here).
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     python3 -m pip install --break-system-packages \
         --pre --index-url "${THEROCK_INDEX_URL}" \
         "rocm[libraries,devel,device-gfx950]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
     rocm-sdk init
 
-ENV ROCM_HOME=/opt/rocm
-ENV PATH="/opt/rocm/bin:${PATH}"
-# Don't bake LD_LIBRARY_PATH=/opt/rocm/lib: on multi-arch installs that
-# routes libhipblaslt/librccl through _rocm_sdk_devel/lib, which is
-# missing per-arch device files (bridging gap). Leaving it unset lets
-# user-set LD_LIBRARY_PATH win and the wheel's RUNPATH otherwise.
+# Export NO ROCm env: this image is intentionally /opt/rocm-less. ROCm resolves
+# via the JAX wheel's $ORIGIN-relative RUNPATHs into the pip _rocm_sdk_* packages
+# (ROCm/jax PR #781); `rocm-sdk path` gives the root/binaries. Pointing
+# ROCM_HOME/PATH at a nonexistent /opt/rocm breaks .info/version lookups and
+# re-masks the RUNPATH gaps this image exists to surface. Consumers needing
+# /opt/rocm can `ln -sfn "$(rocm-sdk path --root)" /opt/rocm` at runtime (but not
+# LD_LIBRARY_PATH=/opt/rocm/lib: that routes libhipblaslt/librccl through
+# _rocm_sdk_devel/lib, which lacks per-arch device files).
 
 # Install GitHub CLI (gh):
 RUN --mount=type=cache,target=/var/cache/apt \

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -10,20 +10,19 @@ ARG THEROCK_VERSION=""
 RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y patchelf numactl-devel vim-common
 
-# Install TheRock (ROCm via pip), initialize the SDK, and create a
-# conventional /opt/rocm symlink so ENV directives use a known path.
-# manylinux_2_28's system python3 (3.6) lacks pip; use a /opt/python/ build.
+# Install TheRock (ROCm via pip) and initialize the SDK. Stay /opt/rocm-less
+# (like the ubuntu base image): ROCm resolves via the JAX wheel's RUNPATHs into
+# the pip _rocm_sdk_* packages, and the build reads the SDK root from
+# `rocm-sdk path --root` (see ci/build_rocm_artifacts.sh) -- no /opt/rocm and no
+# ROCm env vars needed. manylinux_2_28's system python3 (3.6) lacks pip, so use
+# a /opt/python/ build and symlink its rocm-sdk onto PATH (not a /opt/rocm
+# symlink, just build plumbing so `rocm-sdk` is callable below).
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     /opt/python/cp312-cp312/bin/python3 -m pip install \
         --pre --index-url "${THEROCK_INDEX_URL}" \
         "rocm[libraries,devel,device-gfx950]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
     ln -sf /opt/python/cp312-cp312/bin/rocm-sdk /usr/local/bin/rocm-sdk && \
-    rocm-sdk init && \
-    ln -sfn "$(rocm-sdk path --root)" /opt/rocm
-
-ENV ROCM_HOME=/opt/rocm
-ENV PATH="/opt/rocm/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/opt/rocm/lib"
+    rocm-sdk init
 
 RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/local/bin/python && \
     python -m ensurepip && python -m pip install auditwheel


### PR DESCRIPTION
## Motivation

Make TheRock base and manylinux Docker images fully /opt/rocm-less by dropping the /opt/rocm symlinks and ROCM_HOME/PATH/LD_LIBRARY_PATH env vars, relying solely on the pip _rocm_sdk_* packages and wheel RUNPATHs.


## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
