### PR TITLE
Fix: Scope MIOpen from-source rebuild to ROCm 7.2.x

### DIFF
--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -130,7 +130,7 @@ RUN --mount=type=cache,target=/var/cache/apt   \
 # Temporarily include a custom built MIOpen. This should be removed
 # as soon as https://github.com/ROCm/rocm-libraries/pull/4472 lands
 # in a ROCm release that we can install as deb package or with therock.
-RUN [ "$ROCM_VERSION" = "7.1.1" ] || (       \
+RUN [ "${ROCM_VERSION%.*}" != "7.2" ] || (    \
     git clone https://github.com/ROCm/rocm-libraries.git --branch fix/stack-overflow-kernel-init --depth 1 /rocm-libraries && \
     apt update &&                              \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Motivation

Restricts the custom MIOpen from-source rebuild to only the ROCm 7.2.x series, rather than running for every version except 7.1.1.
Uses POSIX shell parameter expansion (${ROCM_VERSION%.*}) to check major.minor, so 7.2.0, 7.2.1, etc. trigger the patch while 7.1.x, 7.12.x, and beyond skip it.

## Technical Details

Changed the conditional check in docker/Dockerfile.base-ubu24 (line 133):

Before:

RUN [ "$ROCM_VERSION" = "7.1.1" ] || (  \

After:

RUN [ "${ROCM_VERSION%.*}" != "7.2" ] || ( \

The old logic rebuilt MIOpen for every ROCm version except 7.1.1 
The new logic only rebuilds MIOpen when ROCM_VERSION starts with 7.2 (e.g., 7.2.0, 7.2.1), which is the only series affected by the __habs ambiguity issue in hiprtc_runtime.h.
Reference: https://github.com/ROCm/rocm-libraries/pull/4472

## Test Plan

Build the Docker image with ROCm 7.2.x and verify that the MIOpen from-source rebuild is triggered.
Build the Docker image with ROCm 7.1.x or 7.14.x and verify that the MIOpen rebuild step is skipped.

## Test Result

On v0.9.1 Docker (where this fix already exists): All LSTM tests pass.
On v0.9.2 Docker (without this fix): LSTM tests fail with miopenStatusUnknownError due to HIPRTC compilation failure.
On v0.9.2 Docker (with this fix applied): LSTM tests pass (MIOpen rebuilt from patched source, __habs ambiguity resolved).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
