### PR TITLE
Disable the MIOpen user level database

### DIFF
--- a/docker/Dockerfile.base-therock-ubu24
+++ b/docker/Dockerfile.base-therock-ubu24
@@ -129,6 +129,9 @@ RUN --mount=type=cache,target=/var/cache/apt   \
     rm llvm.sh &&                              \
     apt-get clean && rm -rf /var/lib/apt/lists/* )
 
+ENV MIOPEN_FIND_ENFORCE=SEARCH_DB_UPDATE
+ENV MIOPEN_USER_DB_PATH=/dev/null
+
 LABEL com.amdgpu.therock_index_url="$THEROCK_INDEX_URL" \
       com.amdgpu.therock_version="$THEROCK_VERSION" \
       com.amdgpu.python_versions="3.11,3.12,3.13,3.13-nogil,3.14,3.14-nogil" \

--- a/docker/Dockerfile.base-ubu24
+++ b/docker/Dockerfile.base-ubu24
@@ -160,6 +160,7 @@ RUN [ "$ROCM_VERSION" = "7.1.1" ] || (       \
 
 # This mitigates crashes related to the kernel database.
 ENV MIOPEN_FIND_ENFORCE=SEARCH_DB_UPDATE
+ENV MIOPEN_USER_DB_PATH=/dev/null
 
 # Temporarily include a custom built ROCR-Runtime. This should be removed
 # as soon as https://github.com/ROCm/rocm-systems/pull/2185 lands


### PR DESCRIPTION
We suspect this is the root cause of flackyness.

We want to build containers and check with upstream CI.
